### PR TITLE
update/authorization

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -16,7 +16,7 @@ class ActivityEntriesController < ApplicationController
   end
 
   def create
-    @app = current_user.permitted_apps.kept.find_by_name!(params[:app_id])
+    @app = current_user.associated_apps.kept.find_by_name!(params[:app_id])
     authorize! :update, @app
 
     @entry = ActivityEntry.new(activity_entry_params)
@@ -59,7 +59,7 @@ class ActivityEntriesController < ApplicationController
   end
 
   def stats
-    app = current_user.permitted_apps.find_by_name!(params[:app_id])
+    app = current_user.associated_apps.find_by_name!(params[:app_id])
     authorize! :read, app
     if app
       render json: ActivityEntry.chart_stats(app.id, 7)
@@ -82,9 +82,9 @@ class ActivityEntriesController < ApplicationController
 
   def app_activity
     if params[:app_id].present?
-      current_user.permitted_apps.find_by_name(params[:app_id]).activity_entries
+      current_user.associated_apps.find_by_name(params[:app_id]).activity_entries
     else
-      User.includes(permitted_apps: :activity_entries).find(current_user.id).permitted_apps.flat_map(&:activity_entries)
+      current_user.associated_activity_entries
     end
   end
 

--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -57,7 +57,7 @@ class ActivityEntriesController < ApplicationController
   end
 
   def stats
-    app = App.accessible_by(Ability.new(current_user)).find_by_name!(params[:app_id])
+    app = current_user.permitted_apps.find_by_name!(params[:app_id])
     authorize! :read, app
     if app
       render json: ActivityEntry.chart_stats(app.id, 7)
@@ -80,9 +80,9 @@ class ActivityEntriesController < ApplicationController
 
   def app_activity
     if params[:app_id].present?
-      App.accessible_by(Ability.new(current_user)).find_by_name(params[:app_id]).activity_entries
+      current_user.permitted_apps.find_by_name(params[:app_id]).activity_entries
     else
-      ActivityEntry.accessible_by(Ability.new(current_user)).all
+      User.includes(permitted_apps: :activity_entries).find(current_user.id).permitted_apps.flat_map(&:activity_entries)
     end
   end
 

--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -16,11 +16,13 @@ class ActivityEntriesController < ApplicationController
   end
 
   def create
-    authorize! :create, ActivityEntry
+    @app = current_user.permitted_apps.kept.find_by_name!(params[:app_id])
+    authorize! :update, @app
+
     @entry = ActivityEntry.new(activity_entry_params)
     @entry.user = current_user
     @entry.owner = current_user
-    @entry.app = current_user.apps.kept.find_by_name!(params[:app_id])
+    @entry.app = @app
     @entry.save!
     render status: :created, json: @entry.activity_attributes
   end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -30,7 +30,6 @@ class AppsController < ApplicationController
     @app.user = current_user
     @app.owner = current_user
     @app.save!
-    @app.grant_all(user_ids: current_user.id)
     render json: @app.as_json(methods: [:aws_role])
   end
 
@@ -79,7 +78,7 @@ class AppsController < ApplicationController
   end
 
   def apps
-    @apps ||= current_user.permitted_apps
+    @apps ||= current_user.associated_apps
     @apps = @apps.find_by_all_tags(tagged_with_params) if tagged_with_params.present?
     if params[:include_deleted].present?
       @apps.order(:descriptive_name)

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -79,7 +79,7 @@ class AppsController < ApplicationController
   end
 
   def apps
-    @apps ||= App.accessible_by(Ability.new(current_user))
+    @apps ||= current_user.permitted_apps
     @apps = @apps.find_by_all_tags(tagged_with_params) if tagged_with_params.present?
     if params[:include_deleted].present?
       @apps.order(:descriptive_name)

--- a/app/controllers/credential_sets_controller.rb
+++ b/app/controllers/credential_sets_controller.rb
@@ -3,7 +3,7 @@ class CredentialSetsController < ApplicationController
   before_action :authenticate_app!, only: [:patch]
 
   def index
-    render json: {credential_sets: current_user.credential_sets.order(:id).map(&:api_attrs)}
+    render json: {credential_sets: current_user.associated_credential_sets.order(:id).map(&:api_attrs)}
   end
 
   def create
@@ -69,11 +69,11 @@ class CredentialSetsController < ApplicationController
   private
 
   def credential_set
-    @credential_set ||= current_user.credential_sets.find_by_external_id!(params[:id])
+    @credential_set ||= current_user.associated_credential_sets.find_by_external_id!(params[:id])
   end
 
   def patchable_credential_set
-    @credential_set ||= current_app.user.credential_sets.find_by_external_id!(params[:id])
+    @credential_set ||= current_app.user.associated_credential_sets.find_by_external_id!(params[:id])
   end
 
   def credential_set_params

--- a/app/controllers/credential_sets_controller.rb
+++ b/app/controllers/credential_sets_controller.rb
@@ -13,7 +13,6 @@ class CredentialSetsController < ApplicationController
     if params.has_key?(:credentials)
       @credential_set.credentials.secret_value = params[:credentials]
       @credential_set.credentials.save!
-      @credential_set.grant_all(user_ids: current_user.id)
     end
     render json: {credential_set: @credential_set.api_attrs}
   end

--- a/app/controllers/manifest_drafts_controller.rb
+++ b/app/controllers/manifest_drafts_controller.rb
@@ -6,7 +6,6 @@ class ManifestDraftsController < ApplicationController
 
   def create
     @manifest_draft = ManifestDraft.create_for_manifest!(manifest, manifest_draft_params)
-    @manifest_draft.grant_all(user_ids: @manifest_draft.owner.id)
     render json: @manifest_draft
   end
 

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -9,7 +9,6 @@ class ManifestsController < ApplicationController
         manifest.user_id = current_user.id
         manifest.owner = current_user
         if manifest.save
-            manifest.grant_all(user_ids: current_user.id)
             render json: manifest, adapter: :attributes, status: :created
         else
             render_bad_request manifest
@@ -37,11 +36,7 @@ class ManifestsController < ApplicationController
     end
 
     def manifests
-        current_user.permitted_manifests
-            .where(
-                permissions: { permit: Permission::READ_BIT }, 
-                app_id: params[:app_id]
-            ).order(created_at: :desc)
+        current_user.associated_manifests.where(app_id: params[:app_id]).order(created_at: :desc)
     end
 
     def manifest_params

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,9 +1,7 @@
 class ManifestsController < ApplicationController
 
     def index
-        byebug
-        @manifests = current_user.permitted_manifests
-        render json: @manifests, adapter: :attributes
+        render json: manifests, adapter: :attributes
     end
 
     def create
@@ -36,6 +34,14 @@ class ManifestsController < ApplicationController
 
     def manifest
         @manifest ||= Manifest.find(params[:id])
+    end
+
+    def manifests
+        current_user.permitted_manifests
+            .where(
+                permissions: { permit: Permission::READ_BIT }, 
+                app_id: params[:app_id]
+            ).order(created_at: :desc)
     end
 
     def manifest_params

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,8 +1,8 @@
 class ManifestsController < ApplicationController
-
-    load_and_authorize_resource
+    load_resource
 
     def index
+        authorize! :read, manifests
         render json: manifests, adapter: :attributes
     end
 
@@ -19,10 +19,12 @@ class ManifestsController < ApplicationController
     end
 
     def show
+        authorize! :read, manifest
         render json: manifest, adapter: :attributes
     end
 
     def update
+        authorize! :update, manifest
         if manifest.update(manifest_params)
             render json: manifest, adapter: :attributes
         else

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,9 +1,9 @@
 class ManifestsController < ApplicationController
-    load_resource
 
     def index
-        authorize! :read, manifests
-        render json: manifests, adapter: :attributes
+        byebug
+        @manifests = current_user.permitted_manifests
+        render json: @manifests, adapter: :attributes
     end
 
     def create
@@ -35,13 +35,7 @@ class ManifestsController < ApplicationController
     private
 
     def manifest
-        # @manifest is already loaded and authorized
-        @manifest
-    end
-
-    def manifests
-        # @manifests is already loaded and authorized
-        @manifests.where(app_id: params[:app_id]).order(created_at: :desc)
+        @manifest ||= Manifest.find(params[:id])
     end
 
     def manifest_params

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -11,6 +11,7 @@ class PermissionsController < ApplicationController
 
   # GET /permissions/:permissible_type/:permissible_id
   def index_resource
+    authorize! :grant, @permissible
     permissions = Permission.where(permissible: @permissible)
     permissions = Permission.group_by_resource(permissions)
     render json: permissions, status: :ok
@@ -18,6 +19,7 @@ class PermissionsController < ApplicationController
 
   # POST /permission/:permit/:permissible_type/:permissible_id/users/:user_id
   def grant
+    authorize! :grant, @permissible
     if @permissible.grant(user_ids: @user.id, permit: params[:permit].to_sym)
       permissions = Permission.where(permissible: @permissible, user: @user)
       permissions = Permission.group_by_user(permissions)
@@ -29,6 +31,7 @@ class PermissionsController < ApplicationController
 
   # POST /permissions/:permissible_type/:permissible_id/users/:user_id
   def grant_all
+    authorize! :grant, @permissible
     if @permissible.grant_all(user_ids: @user.id)
       permissions = Permission.where(permissible: @permissible, user: @user)
       permissions = Permission.group_by_user(permissions)
@@ -40,6 +43,7 @@ class PermissionsController < ApplicationController
 
   # DELETE /permission/:permit/:permissible_type/:permissible_id/users/:user_id
   def revoke
+    authorize! :revoke, @permissible
     if @permissible.revoke(user_ids: @user.id, permit: params[:permit].to_sym)
       render json: { message: 'Revoke OK' }, status: :no_content
     else 
@@ -49,6 +53,7 @@ class PermissionsController < ApplicationController
 
   # DELETE /permissions/:permissible_type/:permissible_id/users/:user_id
   def revoke_all
+    authorize! :revoke, @permissible
     if @permissible.revoke_all(user_ids: @user.id)
       render json: { message: 'Revoke All OK' }, status: :no_content
     else 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,6 +2,7 @@
 
 class Ability
   include CanCan::Ability
+  include PermissionConstants
 
   def initialize(user)
 
@@ -32,61 +33,27 @@ class Ability
       organization.org_roles.find_by(user: user)&.role == 'admin'
     end
 
-    # Until we have UI in place to support admin filtering by customer, this would be too much
-    # Admins can manage everything
-    # if user.admin?
-    #   can :manage, :all
-    # end
+    
+    can :manage, ActivityEntry, owner: user
+    can :manage, App, owner: user
+    can :manage, CredentialSet, owner: user
+    can :manage, Manifest, owner: user
+    can :manage, ManifestDraft, owner: user
 
-    # Users with no customers can manage their own resources
-    can :manage, ActivityEntry, user: user
-    can :manage, App, user: user
-    can :manage, CredentialSet, user: user
-    can :manage, Manifest, user: user
-    can :manage, ManifestDraft, user: user
-
-    # Users with customers can read their teammates' resources
-    return unless user.customers.length > 0
-    can :read, ActivityEntry, user_id: shared_customer_scope(user)
-    can :read, App, user_id: shared_customer_scope(user)
-    can :read, CredentialSet, user_id: shared_customer_scope(user) # exposes the existance of the credentialSet, but not the values
-    can :read, Manifest, user_id: shared_customer_scope(user)
-
-    if user.admin?
-      can :manage, ActivityEntry, user_id: shared_customer_scope(user)
-      can :manage, App, user_id: shared_customer_scope(user)
-      can :manage, CredentialSet, user_id: shared_customer_scope(user) # exposes the existance of the credentialSet, but not the values
-      can :manage, Manifest, user_id: shared_customer_scope(user)
+    can :read, ActivityEntry do |entry|
+      Permission.find_by(permissible: entry.app, user: user, permit: READ_BIT)
     end
-
-    # Define abilities for the user here. For example:
-    #
-    #   return unless user.present?
-    #   can :read, :all
-    #   return unless user.admin?
-    #   can :manage, :all
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, published: true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+    can :read, App do |app|
+      Permission.find_by(permissible: app, user: user, permit: READ_BIT)
+    end
+    can :read, CredentialSet do |credential|
+      Permission.find_by(permissible: credential, user: user, permit: READ_BIT)
+    end
+    can :read, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: READ_BIT)
+    end
+    can :read, ManifestDraft do |draft|
+      Permission.find_by(permissible: draft, user: user, permit: READ_BIT)
+    end
   end
-
-  def shared_customer_scope(user)
-     user.customers.map{ |c| c.users.map{ |u| u.id }}.flatten
-  end
-
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,6 +36,9 @@ class Ability
     can [:manage, :grant, :revoke, :transfer], ActivityEntry do |entry|
       entry.app.admin?(user)
     end
+    can [:read], ActivityEntry do |entry|
+      entry.app.member?(user)
+    end
     can :read, ActivityEntry do |entry|
       Permission.find_by(permissible: entry.app, user: user, permit: READ_BIT)
     end
@@ -49,6 +52,9 @@ class Ability
     # App Permission Blocks
     can [:manage, :grant, :revoke, :transfer], App do |app|
       app.admin?(user)
+    end
+    can [:read], App do |app|
+      app.member?(user)
     end
     can :read, App do |app|
       Permission.find_by(permissible: app, user: user, permit: READ_BIT)
@@ -70,6 +76,7 @@ class Ability
     can [:manage, :grant, :revoke, :transfer], CredentialSet do |credential|
       credential.admin?(user)
     end
+    # What you do not see is CredentialSet :read via org membership. This is deliberate.
     can :read, CredentialSet do |credential|
       Permission.find_by(permissible: credential, user: user, permit: READ_BIT)
     end
@@ -90,6 +97,9 @@ class Ability
     can [:manage, :grant, :revoke, :transfer], Manifest do |manifest|
       manifest.admin?(user)
     end
+    can [:read], Manifest do |manifest|
+      manifest.member?(user)
+    end
     can :read, Manifest do |manifest|
       Permission.find_by(permissible: manifest, user: user, permit: READ_BIT)
     end
@@ -109,6 +119,9 @@ class Ability
     # ManifestDraft Permission Blocks
     can [:manage, :grant, :revoke, :transfer], ManifestDraft do |draft|
       draft.admin?(user)
+    end
+    can [:read], ManifestDraft do |draft|
+      draft.member?(user)
     end
     can :read, ManifestDraft do |draft|
       Permission.find_by(permissible: draft, user: user, permit: READ_BIT)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -54,6 +54,12 @@ class Ability
     can :destroy, App do |app|
       Permission.find_by(permissible: app, user: user, permit: DELETE_BIT)
     end
+    can :grant, App do |app|
+      Permission.find_by(permissible: app, user: user, permit: GRANT_BIT)
+    end
+    can :revoke, App do |app|
+      Permission.find_by(permissible: app, user: user, permit: REVOKE_BIT)
+    end
 
     # CredentialSet Permission Blocks
     can :read, CredentialSet do |credential|
@@ -64,6 +70,12 @@ class Ability
     end
     can :destroy, CredentialSet do |credential|
       Permission.find_by(permissible: credential, user: user, permit: DELETE_BIT)
+    end
+    can :grant, CredentialSet do |credential|
+      Permission.find_by(permissible: credential, user: user, permit: GRANT_BIT)
+    end
+    can :revoke, CredentialSet do |credential|
+      Permission.find_by(permissible: credential, user: user, permit: REVOKE_BIT)
     end
 
     # Manifest Permission Blocks
@@ -76,6 +88,12 @@ class Ability
     can :destroy, Manifest do |manifest|
       Permission.find_by(permissible: manifest, user: user, permit: DELETE_BIT)
     end
+    can :grant, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: GRANT_BIT)
+    end
+    can :revoke, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: REVOKE_BIT)
+    end
     
     # ManifestDraft Permission Blocks
     can :read, ManifestDraft do |draft|
@@ -86,6 +104,12 @@ class Ability
     end
     can :destroy, ManifestDraft do |draft|
       Permission.find_by(permissible: draft, user: user, permit: DELETE_BIT)
+    end
+    can :grant, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: GRANT_BIT)
+    end
+    can :revoke, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: REVOKE_BIT)
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,27 +33,59 @@ class Ability
       organization.org_roles.find_by(user: user)&.role == 'admin'
     end
 
-    
-    can :manage, ActivityEntry, owner: user
-    can :manage, App, owner: user
-    can :manage, CredentialSet, owner: user
-    can :manage, Manifest, owner: user
-    can :manage, ManifestDraft, owner: user
-
+    # ActivityEntry blocks Permission Blocks
     can :read, ActivityEntry do |entry|
       Permission.find_by(permissible: entry.app, user: user, permit: READ_BIT)
     end
+    can :update, ActivityEntry do |entry|
+      Permission.find_by(permissible: entry.app, user: user, permit: UPDATE_BIT)
+    end
+    can :destroy, ActivityEntry do |entry|
+      Permission.find_by(permissible: entry.app, user: user, permit: DELETE_BIT)
+    end
+
+    # App Permission Blocks
     can :read, App do |app|
       Permission.find_by(permissible: app, user: user, permit: READ_BIT)
     end
+    can :update, App do |app|
+      Permission.find_by(permissible: app, user: user, permit: UPDATE_BIT)
+    end
+    can :destroy, App do |app|
+      Permission.find_by(permissible: app, user: user, permit: DELETE_BIT)
+    end
+
+    # CredentialSet Permission Blocks
     can :read, CredentialSet do |credential|
       Permission.find_by(permissible: credential, user: user, permit: READ_BIT)
     end
+    can :update, CredentialSet do |credential|
+      Permission.find_by(permissible: credential, user: user, permit: UPDATE_BIT)
+    end
+    can :destroy, CredentialSet do |credential|
+      Permission.find_by(permissible: credential, user: user, permit: DELETE_BIT)
+    end
+
+    # Manifest Permission Blocks
     can :read, Manifest do |manifest|
       Permission.find_by(permissible: manifest, user: user, permit: READ_BIT)
     end
+    can :update, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: UPDATE_BIT)
+    end
+    can :destroy, Manifest do |manifest|
+      Permission.find_by(permissible: manifest, user: user, permit: DELETE_BIT)
+    end
+    
+    # ManifestDraft Permission Blocks
     can :read, ManifestDraft do |draft|
       Permission.find_by(permissible: draft, user: user, permit: READ_BIT)
+    end
+    can :update, ManifestDraft do |draft|
+      Permission.find_by(permissible: draft, user: user, permit: UPDATE_BIT)
+    end
+    can :destroy, ManifestDraft do |draft|
+      Permission.find_by(permissible: draft, user: user, permit: DELETE_BIT)
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,6 @@ class Ability
 
   def initialize(user)
 
-
     # all users can read public apps
     can :read, App, readable_by: 'public'
     can :read, Manifest, :app => { readable_by: 'public' }
@@ -34,6 +33,9 @@ class Ability
     end
 
     # ActivityEntry blocks Permission Blocks
+    can [:manage, :grant, :revoke, :transfer], ActivityEntry do |entry|
+      entry.app.admin?(user)
+    end
     can :read, ActivityEntry do |entry|
       Permission.find_by(permissible: entry.app, user: user, permit: READ_BIT)
     end
@@ -45,6 +47,9 @@ class Ability
     end
 
     # App Permission Blocks
+    can [:manage, :grant, :revoke, :transfer], App do |app|
+      app.admin?(user)
+    end
     can :read, App do |app|
       Permission.find_by(permissible: app, user: user, permit: READ_BIT)
     end
@@ -62,6 +67,9 @@ class Ability
     end
 
     # CredentialSet Permission Blocks
+    can [:manage, :grant, :revoke, :transfer], CredentialSet do |credential|
+      credential.admin?(user)
+    end
     can :read, CredentialSet do |credential|
       Permission.find_by(permissible: credential, user: user, permit: READ_BIT)
     end
@@ -79,6 +87,9 @@ class Ability
     end
 
     # Manifest Permission Blocks
+    can [:manage, :grant, :revoke, :transfer], Manifest do |manifest|
+      manifest.admin?(user)
+    end
     can :read, Manifest do |manifest|
       Permission.find_by(permissible: manifest, user: user, permit: READ_BIT)
     end
@@ -96,6 +107,9 @@ class Ability
     end
     
     # ManifestDraft Permission Blocks
+    can [:manage, :grant, :revoke, :transfer], ManifestDraft do |draft|
+      draft.admin?(user)
+    end
     can :read, ManifestDraft do |draft|
       Permission.find_by(permissible: draft, user: user, permit: READ_BIT)
     end

--- a/app/models/concerns/ownable.rb
+++ b/app/models/concerns/ownable.rb
@@ -11,14 +11,17 @@ module Ownable
     end
     self.update(owner: new_owner)
 
-    if new_owner.is_a?(User)
-      self.grant_all(user_ids: new_owner.id)
-    else # new_owner is Organization
-      admins = new_owner.org_roles.where(role: 'admin').pluck(:user_id)
+    if new_owner.is_a?(Organization)
       members = new_owner.org_roles.where(role: 'member').pluck(:user_id)
-
-      self.grant_all(user_ids: admins)
       self.grant(user_ids: members, permit: :read)
+    end
+  end
+
+  def admin?(user)
+    if self.owner.is_a?(User)
+      self.owner == user
+    else # owner is Organization
+      self.owner.org_roles.exists?(user: user, role: 'admin')
     end
   end
 end

--- a/app/models/concerns/ownable.rb
+++ b/app/models/concerns/ownable.rb
@@ -24,4 +24,13 @@ module Ownable
       self.owner.org_roles.exists?(user: user, role: 'admin')
     end
   end
+
+  def member?(user)
+    if self.owner.is_a?(User)
+      self.owner == user
+    else # owner is Organization
+      self.owner.org_roles.exists?(user: user, role: 'member')
+    end
+  end
+
 end

--- a/app/models/concerns/ownable.rb
+++ b/app/models/concerns/ownable.rb
@@ -9,12 +9,8 @@ module Ownable
 
       self.revoke_all(user_ids: previously_permitted_users)
     end
-    self.update(owner: new_owner)
 
-    if new_owner.is_a?(Organization)
-      members = new_owner.org_roles.where(role: 'member').pluck(:user_id)
-      self.grant(user_ids: members, permit: :read)
-    end
+    self.update(owner: new_owner)
   end
 
   def admin?(user)

--- a/app/models/concerns/permissible.rb
+++ b/app/models/concerns/permissible.rb
@@ -5,12 +5,9 @@ module Permissible
   # takes a user or array of users and grants them a specific permission for the given permissible
   def grant(user_ids:, permit:)
     user_ids = Array(user_ids)
-    permissions = Permission.where(permissible: self, user_id: user_ids)
+    permissions = Permission.where(permissible: self, user_id: user_ids, permit: PERMISSIONS_HASH[permit])
+    user_ids = user_ids - permissions.pluck(:user_id)
 
-    permissions.where(permit: NO_PERMIT_BIT).update_all(permit: PERMISSIONS_HASH[permit])
-    permits_exist = permissions.where(permit: PERMISSIONS_HASH[permit]).pluck(:user_id)
-
-    user_ids = user_ids - permits_exist
     permits_to_create = []
     user_ids.each do |user_id| 
       permits_to_create << { 
@@ -26,23 +23,13 @@ module Permissible
   def revoke(user_ids:, permit:)
     user_ids = Array(user_ids)
     permissions = Permission.where(permissible: self, user_id: user_ids, permit: PERMISSIONS_HASH[permit])
-    user_ids = permissions.pluck(:user_id)
-
-    permits_to_delete = Permission.none
-    user_ids.each do |user_id|
-      if Permission.where(permissible: self, user_id: user_id).count > 1
-        permits_to_delete = permits_to_delete.or(permissions.where(user_id: user_id))
-      end
-    end
-    permissions.where.not(user_id: permits_to_delete.pluck(:user_id)).update_all(permit: NO_PERMIT_BIT)
-    permits_to_delete.delete_all
+    permissions.delete_all
   end
 
   # takes a user or array of users and grants them all possible permissions for a given permissible
   def grant_all(user_ids:)
     user_ids = Array(user_ids)
     existing_permits = Permission.where(permissible: self, user_id: user_ids)
-    existing_permits.where(permit: NO_PERMIT_BIT).delete_all
 
     permits_to_create = []
     user_ids.each do |user_id|
@@ -62,19 +49,6 @@ module Permissible
   def revoke_all(user_ids:)
     user_ids = Array(user_ids)
     permissions = Permission.where(permissible: self, user_id: user_ids)
-    return unless permissions.count > 0
-
-    user_ids = permissions.distinct.pluck(:user_id)
     permissions.delete_all
-
-    permits_to_create = []
-    user_ids.each do |user_id|
-      permits_to_create << { 
-        permissible: self, 
-        user_id: user_id, 
-        permit: NO_PERMIT_BIT 
-      }
-    end
-    Permission.create(permits_to_create)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,7 @@ class User < ActiveRecord::Base
   end
 
   def associated_activity_entries
-    associated_resources_via_app('manifests')
+    associated_resources_via_app('activity_entries')
   end
   
   # Only explicitly shared credential sets are exposed and are  not visibile via org membership alone
@@ -82,17 +82,21 @@ class User < ActiveRecord::Base
 
   def associated_resources(resource_type, roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
+
     orgs = self.organizations.where(org_roles: { role: roles })
     membership_associated = model_class.where(owner: [self] + orgs)
     permitted = model_class.where(id: self.send("permitted_#{resource_type}").pluck(:id))
+
     membership_associated.or(permitted)
   end
 
   def associated_resources_via_app(resource_type, roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
+
     orgs = self.organizations.where(org_roles: { role: roles })
     membership_associated = model_class.where(app: App.where(owner: [self] + orgs))
-    permitted = model_class.where(app: App.where(id: "permitted_apps").pluck(:id))
+    permitted = model_class.where(app: App.where(id: self.permitted_apps.pluck(:id)))
+
     membership_associated.or(permitted)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,9 @@ class User < ActiveRecord::Base
   # new permission based associations
   has_many :permissions
   has_many :permitted_apps, through: :permissions, source: :permissible, source_type: 'App'
+  has_many :permitted_manifests, through: :permissions, source: :permissible, source_type: 'Manifest'
+  has_many :permitted_manifest_drafts, through: :permissions, source: :permissible, source_type: 'ManifestDraft'
+  has_many :permitted_credential_sets, through: :permissions, source: :permissible, source_type: 'CredentialSet'
 
   enum role: %i[member admin client]
   enum approval: %i[pending approved rejected]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,10 +27,10 @@ class User < ActiveRecord::Base
   
   # new permission based associations
   has_many :permissions
-  has_many :permitted_apps, through: :permissions, source: :permissible, source_type: 'App'
-  has_many :permitted_manifests, through: :permissions, source: :permissible, source_type: 'Manifest'
-  has_many :permitted_manifest_drafts, through: :permissions, source: :permissible, source_type: 'ManifestDraft'
-  has_many :permitted_credential_sets, through: :permissions, source: :permissible, source_type: 'CredentialSet'
+  has_many :permitted_apps, -> { distinct }, through: :permissions, source: :permissible, source_type: 'App'
+  has_many :permitted_manifests, -> { distinct }, through: :permissions, source: :permissible, source_type: 'Manifest'
+  has_many :permitted_manifest_drafts, -> { distinct }, through: :permissions, source: :permissible, source_type: 'ManifestDraft'
+  has_many :permitted_credential_sets, -> { distinct }, through: :permissions, source: :permissible, source_type: 'CredentialSet'
 
   enum role: %i[member admin client]
   enum approval: %i[pending approved rejected]

--- a/db/migrate/20231031212357_change_manifest_content_type.rb
+++ b/db/migrate/20231031212357_change_manifest_content_type.rb
@@ -1,0 +1,9 @@
+class ChangeManifestContentType < ActiveRecord::Migration[7.0]
+  def up
+    change_column :manifests, :content, :jsonb
+  end
+
+  def down
+    change_column :manifests, :content, :json
+  end
+end

--- a/db/migrate/20231102164239_remove_permits_from_owners.rb
+++ b/db/migrate/20231102164239_remove_permits_from_owners.rb
@@ -1,0 +1,35 @@
+class RemovePermitsFromOwners < ActiveRecord::Migration[7.0]
+  def up
+    User.all.each do |user|
+      user.owned_apps.each do |app|
+        app.revoke_all(user_ids: user.id)
+      end
+      user.owned_manifests.each do |manifest|
+        manifest.revoke_all(user_ids: user.id)
+      end
+      user.owned_manifest_drafts.each do |manifest_draft|
+        manifest_draft.revoke_all(user_ids: user.id)
+      end
+      user.owned_credential_sets.each do |credential_set|
+        credential_set.revoke_all(user_ids: user.id)
+      end
+    end
+  end
+
+  def down
+    User.all.each do |user|
+      user.owned_apps.each do |app|
+        app.grant_all(user_ids: user.id)
+      end
+      user.owned_manifests.each do |manifest|
+        manifest.grant_all(user_ids: user.id)
+      end
+      user.owned_manifest_drafts.each do |manifest_draft|
+        manifest_draft.grant_all(user_ids: user.id)
+      end
+      user.owned_credential_sets.each do |credential_set|
+        credential_set.grant_all(user_ids: user.id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_31_212357) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_164239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_27_152305) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_31_212357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_27_152305) do
 
   create_table "manifests", force: :cascade do |t|
     t.string "app_id"
-    t.json "content"
+    t.jsonb "content"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/concerns/ownable_spec.rb
+++ b/spec/concerns/ownable_spec.rb
@@ -6,7 +6,7 @@ describe Ownable do
   let(:user3) { FactoryBot.create(:user) }
   let(:organization1) { FactoryBot.create(:organization, admin: user1, members_count: 2) }
   let(:organization2) { FactoryBot.create(:organization, admin: user2, members_count: 2) }
-  let(:ownable) { FactoryBot.create(:app, :permissible, custom_owner: old_owner) }
+  let(:ownable) { FactoryBot.create(:app, custom_owner: old_owner) }
 
   describe '#transfer_ownership' do
     describe "previous permissions" do

--- a/spec/concerns/ownable_spec.rb
+++ b/spec/concerns/ownable_spec.rb
@@ -60,17 +60,6 @@ describe Ownable do
             ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
           }.to change(ownable, :owner).to(new_owner)
         end
-
-        it 'grants the correct permissions to the new owner' do
-          new_owner_permits = Permission.where(permissible: ownable, user_id: new_owner.id)
-          expect(new_owner_permits.count).to eq(0)
-
-          expect {
-            ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
-          }.to change(new_owner_permits, :count).to(Permission::PERMISSIONS_HASH.length)
-
-          expect(new_owner_permits.pluck(:permit)).to eq(Permission::PERMISSIONS_HASH.values)
-        end
       end
 
       context 'transfer ownership to an Organization' do
@@ -82,24 +71,54 @@ describe Ownable do
           }.to change(ownable, :owner).to(new_owner)
         end
 
-        it 'grants the correct permissions to the new owner' do
-          admins = new_owner.org_roles.where(role: 'admin').pluck(:user_id)
+        it 'grants the correct permissions to members of the org' do
           members = new_owner.org_roles.where(role: 'member').pluck(:user_id)
-          admin_permits = Permission.where(permissible: ownable, user_id: admins)
           member_permits = Permission.where(permissible: ownable, user_id: members)
 
-          expect(admin_permits.count).to eq(0)
           expect(member_permits.count).to eq(0)
 
           ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
 
-          admin_permits.reload
           member_permits.reload
-          expect(admin_permits.count).to eq(admins.length * Permission::PERMISSIONS_HASH.length)
           expect(member_permits.count).to eq(members.length)
-          expect(admin_permits.pluck(:permit)).to eq((Permission::PERMISSIONS_HASH.values * admins.count).flatten)
           expect(member_permits.pluck(:permit)).to eq(([Permission::READ_BIT] * members.count).flatten)
         end
+      end
+    end
+  end
+
+  describe '#admin?' do
+    context 'resource owner is User' do
+      before do
+        @owner = FactoryBot.create(:user)
+        @ownable = FactoryBot.create(:app, custom_owner: @owner)
+      end
+
+      it 'returns true if user is owner' do
+        expect(@ownable.admin?(@owner)).to eq true
+      end
+      it 'returns false if user is not owner' do
+        @other = FactoryBot.create(:user)
+        expect(@ownable.admin?(@other)).to eq false
+      end
+    end
+    context 'resource owner is Organization' do
+      before do
+        @org = FactoryBot.create(:organization, members_count: 1)
+        @ownable = FactoryBot.create(:app, custom_owner: @org)
+      end
+
+      it 'returns true if user is admin of org' do
+        admin = @org.users.find_by(org_roles: { role: 'admin' })
+        expect(@ownable.admin?(admin)).to eq true
+      end
+      it 'returns false if user is member of org' do
+        member = @org.users.find_by(org_roles: { role: 'member' })
+        expect(@ownable.admin?(member)).to eq false
+      end
+      it 'returns false if user is not part of org' do
+        other = FactoryBot.create(:user)
+        expect(@ownable.admin?(other)).to eq false
       end
     end
   end

--- a/spec/concerns/ownable_spec.rb
+++ b/spec/concerns/ownable_spec.rb
@@ -30,9 +30,7 @@ describe Ownable do
         it 'revokes all previous permissions' do
           expect {
             ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
-          }.to change(@previous_permissions, :count).to(@permitted_users.length)
-
-          expect(@previous_permissions.distinct.pluck(:permit)).to eq([Permission::NO_PERMIT_BIT])
+          }.to change(@previous_permissions, :count).to(0)
         end
       end
 

--- a/spec/concerns/ownable_spec.rb
+++ b/spec/concerns/ownable_spec.rb
@@ -70,19 +70,6 @@ describe Ownable do
             ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
           }.to change(ownable, :owner).to(new_owner)
         end
-
-        it 'grants the correct permissions to members of the org' do
-          members = new_owner.org_roles.where(role: 'member').pluck(:user_id)
-          member_permits = Permission.where(permissible: ownable, user_id: members)
-
-          expect(member_permits.count).to eq(0)
-
-          ownable.transfer_ownership(new_owner: new_owner, revoke: revoke)
-
-          member_permits.reload
-          expect(member_permits.count).to eq(members.length)
-          expect(member_permits.pluck(:permit)).to eq(([Permission::READ_BIT] * members.count).flatten)
-        end
       end
     end
   end

--- a/spec/controllers/apps_spec.rb
+++ b/spec/controllers/apps_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AppsController, :type => :controller do
 
   context "logged in user" do
 
-    let! (:app) { FactoryBot.create(:app, user: user) }
+    let! (:app) { FactoryBot.create(:app, custom_owner: user) }
 
     before do
       login
@@ -38,7 +38,7 @@ RSpec.describe AppsController, :type => :controller do
 
   context "tagged apps" do
 
-    let!(:tagged_app) { FactoryBot.create(:app, user: user) }
+    let!(:tagged_app) { FactoryBot.create(:app, custom_owner: user) }
     let!(:tag) { FactoryBot.create(:tag, taggable: tagged_app, context: 'color', name: 'blue') }
 
     before do

--- a/spec/factories/app.rb
+++ b/spec/factories/app.rb
@@ -17,21 +17,19 @@ FactoryBot.define do
       association :owner, factory: :organization
     end
 
-    trait :permissible do
-      after(:create) do |app, _evaluator|
-        if app.owner.is_a?(User)
-          app.grant_all(
-            user_ids: app.owner.id
-          )
-        else # owner is an Organization
-          app.grant_all(
-            user_ids: app.owner.org_roles.where(role: 'admin').pluck(:user_id)
-          )
-          app.grant(
-            user_ids: app.owner.org_roles.where(role: 'member').pluck(:user_id),
-            permit: :read
-          )
-        end
+    after(:create) do |app, _evaluator|
+      if app.owner.is_a?(User)
+        app.grant_all(
+          user_ids: app.owner.id
+        )
+      else # owner is an Organization
+        app.grant_all(
+          user_ids: app.owner.org_roles.where(role: 'admin').pluck(:user_id)
+        )
+        app.grant(
+          user_ids: app.owner.org_roles.where(role: 'member').pluck(:user_id),
+          permit: :read
+        )
       end
     end
   end

--- a/spec/factories/app.rb
+++ b/spec/factories/app.rb
@@ -18,14 +18,7 @@ FactoryBot.define do
     end
 
     after(:create) do |app, _evaluator|
-      if app.owner.is_a?(User)
-        app.grant_all(
-          user_ids: app.owner.id
-        )
-      else # owner is an Organization
-        app.grant_all(
-          user_ids: app.owner.org_roles.where(role: 'admin').pluck(:user_id)
-        )
+      if app.owner.is_a?(Organization)
         app.grant(
           user_ids: app.owner.org_roles.where(role: 'member').pluck(:user_id),
           permit: :read

--- a/spec/factories/credential_set.rb
+++ b/spec/factories/credential_set.rb
@@ -6,6 +6,14 @@ FactoryBot.define do
     name { 'Twilio' }
     credential_type { 'TwilioCredentials' }
 
+    transient do
+      custom_owner { nil }
+    end
+
+    before(:create) do |credential, evaluator|
+      credential.owner = evaluator.custom_owner if evaluator.custom_owner
+    end
+
     trait :org_owner do
       association :owner, factory: :organization
     end

--- a/spec/factories/manifest.rb
+++ b/spec/factories/manifest.rb
@@ -1,15 +1,28 @@
 FactoryBot.define do
+  factory :manifest do
+    content { '{}'}
+    association :user, factory: :user
+    association :owner, factory: :user
+    association :app, factory: :app
 
-   factory :manifest do
-     app_id { app_id }
-     internal_app_id { internal_app_id } 
-     content { '{}'}
-     association :user, factory: :user
-     association :owner, factory: :user
+    transient do
+      custom_app { nil }
+    end
 
-     trait :org_owner do
-       association :owner, factory: :organization
-     end
-   end
+    before(:create) do |manifest, evaluator|
+      manifest.app = evaluator.custom_app if evaluator.custom_app
+      
+      manifest.app_id = manifest.app.name
+      manifest.internal_app_id = manifest.app.id
+      manifest.owner = manifest.app.owner
+    end
 
- end
+    after(:create) do |manifest, _evaluator|
+      manifest.grant_all(user_ids: manifest.owner.id)
+    end
+
+    trait :org_owner do
+      association :owner, factory: :organization
+    end
+  end
+end

--- a/spec/factories/manifest.rb
+++ b/spec/factories/manifest.rb
@@ -17,10 +17,6 @@ FactoryBot.define do
       manifest.owner = manifest.app.owner
     end
 
-    after(:create) do |manifest, _evaluator|
-      manifest.grant_all(user_ids: manifest.owner.id)
-    end
-
     trait :org_owner do
       association :owner, factory: :organization
     end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -19,16 +19,6 @@ describe Permission do
         expect(permission.permit).to eq(Permission::PERMISSIONS_HASH[:read])
       end
 
-      it 'updates NO_PERMIT_BIT permission instead of creating a new one' do
-        permission = Permission.create(permissible: permissible, user: user, permit: Permission::NO_PERMIT_BIT)
-
-        expect {
-          permissible.grant(user_ids: user.id, permit: :update)
-        }.to_not change(Permission, :count)
-
-        expect(permission.reload.permit).to eq(Permission::PERMISSIONS_HASH[:update])
-      end
-
       it 'does not create a new permission when it was already granted' do
         Permission.create(permissible: permissible, user: user, permit: Permission::READ_BIT)
 
@@ -64,12 +54,12 @@ describe Permission do
         @permission = Permission.create(permissible: permissible, user: user, permit: Permission::READ_BIT)
       end
 
-      it 'changes the permission to NO_PERMIT_BIT when only one permit exists' do
+      it 'destroys the specified permit' do
         expect {
           permissible.revoke(user_ids: user.id, permit: :read)
-        }.not_to change(Permission, :count)
+        }.to change(Permission, :count).by(-1)
 
-        expect(@permission.reload.permit).to eq(Permission::NO_PERMIT_BIT)
+        expect(Permission.exists?(permissible: permissible, user: user, permit: Permission::READ_BIT)).to be false
       end
 
       it 'destroys the specified permission when multiple permissions exist for user and permissible pair' do
@@ -79,7 +69,6 @@ describe Permission do
           permissible.revoke(user_ids: user.id, permit: :read)
         }.to change(Permission, :count).by(-1)
 
-        expect(Permission.exists?(permissible: permissible, user: user, permit: Permission::NO_PERMIT_BIT)).to be false
         expect(Permission.exists?(permissible: permissible, user: user, permit: Permission::READ_BIT)).to be false
         expect(Permission.exists?(permissible: permissible, user: user, permit: Permission::UPDATE_BIT)).to be true
       end
@@ -106,10 +95,9 @@ describe Permission do
       it 'revokes from each user' do
         expect {
           permissible.revoke(user_ids: @user_ids, permit: :read)
-        }.not_to change(Permission, :count)
+        }.to change(Permission, :count).by(-3)
 
-        revoked_permits = Permission.where(permissible: permissible, user_id: @user_ids, permit: Permission::NO_PERMIT_BIT)
-        expect(revoked_permits.count).to eq(3)
+        expect(Permission.exists?(permissible: permissible, user: @user_ids, permit: Permission::READ_BIT)).to be false
       end
 
       it 'correctly deletes permissions' do
@@ -121,7 +109,8 @@ describe Permission do
           permissible.revoke(user_ids: @user_ids, permit: :update)
         }.to change(Permission, :count).by(-3)
 
-        expect(Permission.exists?(permissible: permissible, user_id: @user_ids, permit: Permission::NO_PERMIT_BIT)).to be false
+        expect(Permission.exists?(permissible: permissible, user_id: @user_ids, permit: Permission::READ_BIT)).to be true
+        expect(Permission.exists?(permissible: permissible, user_id: @user_ids, permit: Permission::UPDATE_BIT)).to be false
       end
     end
   end
@@ -132,22 +121,6 @@ describe Permission do
         expect {
           permissible.grant_all(user_ids: user.id)
         }.to change(Permission, :count).by(Permission::PERMISSIONS_HASH.length)
-
-        permissions = Permission.where(permissible: permissible, user_id: user.id)
-        expect(permissions.count).to eq(Permission::PERMISSIONS_HASH.length)
-        expect(permissions.pluck(:permit)).to contain_exactly(*Permission::PERMISSIONS_HASH.values)
-      end
-    end
-
-    context 'when permission with NO_PERMIT_BIT exists' do
-      before do
-        Permission.create(permissible: permissible, user: user, permit: Permission::NO_PERMIT_BIT)
-      end
-
-      it 'deletes the existing permission and grants all permissions' do
-        expect {
-          permissible.grant_all(user_ids: user.id)
-        }.to change(Permission, :count).by(Permission::PERMISSIONS_HASH.length - 1)
 
         permissions = Permission.where(permissible: permissible, user_id: user.id)
         expect(permissions.count).to eq(Permission::PERMISSIONS_HASH.length)
@@ -196,14 +169,13 @@ describe Permission do
         Permission.create(permissible: permissible, user: user, permit: Permission::DELETE_BIT)
       end
       
-      it 'revokes all permissions and sets NO_PERMIT_BIT' do
+      it 'destroys all permissions for specified user' do
         expect {
           permissible.revoke_all(user_ids: user.id)
-        }.to change(Permission, :count).by(-2)
+        }.to change(Permission, :count).by(-3)
 
         permissions = Permission.where(permissible: permissible, user_id: user.id)
-        expect(permissions.count).to eq(1)
-        expect(permissions.first.permit).to eq(Permission::NO_PERMIT_BIT)
+        expect(permissions.count).to eq(0)
       end
 
       it 'does not delete permissions for other users' do
@@ -215,8 +187,7 @@ describe Permission do
         }.not_to change(Permission.where(permissible: permissible, user: @other_user), :count)
 
         permissions = Permission.where(permissible: permissible, user_id: user.id)
-        expect(permissions.count).to eq(1)
-        expect(permissions.first.permit).to eq(Permission::NO_PERMIT_BIT)
+        expect(permissions.count).to eq(0)
         expect(@permit.reload.permit).to eq(Permission::READ_BIT)
       end
 
@@ -229,8 +200,7 @@ describe Permission do
         }.not_to change(Permission.where(permissible: @other_permissible, user: user), :count)
 
         permissions = Permission.where(permissible: permissible, user_id: user.id)
-        expect(permissions.count).to eq(1)
-        expect(permissions.first.permit).to eq(Permission::NO_PERMIT_BIT)
+        expect(permissions.count).to eq(0)
         expect(@permit.reload.permit).to eq(Permission::READ_BIT)
       end
     end
@@ -239,14 +209,6 @@ describe Permission do
       it 'does not attempt any deletions' do
         expect(Permission).not_to receive(:delete_all)
         permissible.revoke_all(user_ids: user.id)
-      end
-
-      it 'does not set a NO_PERMIT_BIT' do
-        permissible.revoke_all(user_ids: user.id)
-
-        permissions = Permission.where(permissible: permissible, user: user)
-        expect(permissions.count).to eq(0)
-        expect(permissions.where(permit: Permission::NO_PERMIT_BIT).empty?).to be true
       end
     end
 
@@ -260,13 +222,10 @@ describe Permission do
         end
       end
 
-      it 'deletes permits and sets NO_PERMIT_BIT for each user' do
+      it 'deletes permits for each user' do
         expect { 
           permissible.revoke_all(user_ids: @user_ids)
-        }.to change(Permission.where(permissible: permissible, user_id: @user_ids), :count).to(3)
-
-        revoked_permits = Permission.where(permissible: permissible, user_id: @user_ids)
-        expect(revoked_permits.pluck(:permit)).to eq([Permission::NO_PERMIT_BIT, Permission::NO_PERMIT_BIT, Permission::NO_PERMIT_BIT])
+        }.to change(Permission.where(permissible: permissible, user_id: @user_ids), :count).to(0)
       end
     end
   end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -4,7 +4,7 @@ describe Permission do
   let(:user) { FactoryBot.create(:user) }
   let(:user2) { FactoryBot.create(:user) }
   let(:user3) { FactoryBot.create(:user) }
-  let(:permissible) { FactoryBot.create(:app) }
+  let!(:permissible) { FactoryBot.create(:app) }
 
   describe 'grant' do
     context 'with valid input' do
@@ -244,8 +244,9 @@ describe Permission do
       it 'does not set a NO_PERMIT_BIT' do
         permissible.revoke_all(user_ids: user.id)
 
-        expect(Permission.count).to eq(0)
-        expect(Permission.where(permit: Permission::NO_PERMIT_BIT).empty?).to be true
+        permissions = Permission.where(permissible: permissible, user: user)
+        expect(permissions.count).to eq(0)
+        expect(permissions.where(permit: Permission::NO_PERMIT_BIT).empty?).to be true
       end
     end
 
@@ -262,7 +263,7 @@ describe Permission do
       it 'deletes permits and sets NO_PERMIT_BIT for each user' do
         expect { 
           permissible.revoke_all(user_ids: @user_ids)
-        }.to change(Permission, :count).to(3)
+        }.to change(Permission.where(permissible: permissible, user_id: @user_ids), :count).to(3)
 
         revoked_permits = Permission.where(permissible: permissible, user_id: @user_ids)
         expect(revoked_permits.pluck(:permit)).to eq([Permission::NO_PERMIT_BIT, Permission::NO_PERMIT_BIT, Permission::NO_PERMIT_BIT])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe User do
+  let(:user) { FactoryBot.create(:user) }
+  let(:other) { FactoryBot.create(:user) }
+  let(:org) { FactoryBot.create(:organization, admin: user, members_count: 1) }
+
+  describe '#associated_apps' do
+    let(:user_app) { FactoryBot.create(:app, custom_owner: user) }
+    let(:org_app) { FactoryBot.create(:app, custom_owner: org) }
+    let(:permitted_app) { FactoryBot.create(:app) }
+    let!(:unrelated_app) { FactoryBot.create(:app) }
+  
+    it 'returns an empty collection if the user has no associated apps' do
+      expect(user.associated_apps).to be_empty
+    end
+    
+    it 'returns permitted resources if they exist' do
+      permitted_app.grant_all(user_ids: user.id)
+      expect(user.associated_apps).to contain_exactly(permitted_app)
+    end
+    
+    it 'returns owned resources if they exist' do
+      user_app
+      expect(user.associated_apps).to contain_exactly(user_app)
+    end
+    
+    it 'returns org associated apps if they exist' do
+      org_app
+      expect(user.associated_apps).to contain_exactly(org_app)
+    end
+    
+    it 'returns all types of associated apps if they exist' do
+      user_app
+      org_app
+      permitted_app.grant_all(user_ids: user.id)
+
+      expect(user.associated_apps).to contain_exactly(user_app, org_app, permitted_app)
+    end
+  end
+
+    describe '#associated_credential_sets' do
+    let(:user_credential) { FactoryBot.create(:credential_set, custom_owner: user) }
+    let(:org_credential) { FactoryBot.create(:credential_set, custom_owner: org) }
+    let(:permitted_credential) { FactoryBot.create(:credential_set) }
+    let!(:unrelated_credential) { FactoryBot.create(:credential_set) }
+  
+    it 'returns an empty collection if the user has no associated credentials' do
+      expect(user.associated_credential_sets).to be_empty
+    end
+    
+    it 'returns permitted resources if they exist' do
+      permitted_credential.grant_all(user_ids: user.id)
+      expect(user.associated_credential_sets).to contain_exactly(permitted_credential)
+    end
+    
+    it 'returns owned resources if they exist' do
+      user_credential
+      expect(user.associated_credential_sets).to contain_exactly(user_credential)
+    end
+    
+    it 'returns org associated credential_sets if they exist' do
+      org_credential
+      expect(user.associated_credential_sets).to contain_exactly(org_credential)
+    end
+    
+    it 'returns all types of associated credential_sets if they exist' do
+      user_credential
+      org_credential
+      permitted_credential.grant_all(user_ids: user.id)
+
+      expect(user.associated_credential_sets).to contain_exactly(user_credential, org_credential, permitted_credential)
+    end
+  end
+
+end

--- a/spec/requests/activity_entries_spec.rb
+++ b/spec/requests/activity_entries_spec.rb
@@ -90,5 +90,4 @@ describe 'Activity Entries API' do
       end
     end
   end
-
 end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -7,7 +7,7 @@ describe 'Apps API' do
   let(:client) { user.tokens.keys.first }
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
-  let!(:user_app) { FactoryBot.create(:app, user: user) }
+  let!(:user_app) { FactoryBot.create(:app, custom_owner: user) }
 
   def self.app_schema
     {

--- a/spec/requests/manifests_spec.rb
+++ b/spec/requests/manifests_spec.rb
@@ -9,8 +9,8 @@ describe 'manifests', type: :request do
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
 
-  let!(:user_app) { FactoryBot.create(:app, user: user ) }
-  let!(:user_manifest) { FactoryBot.create(:manifest, user: user, owner: user, app_id: user_app.name, internal_app_id: user_app.id) }
+  let!(:user_app) { FactoryBot.create(:app, custom_owner: user ) }
+  let!(:user_manifest) { FactoryBot.create(:manifest, custom_app: user_app) }
 
   path '/manifests?app_id={appId}' do
     get('list manifests') do

--- a/spec/requests/permissions_spec.rb
+++ b/spec/requests/permissions_spec.rb
@@ -70,7 +70,7 @@ describe 'Permissions API' do
 
   before do
     @owner = user
-    @permissible = FactoryBot.create(:app, :permissible, custom_owner: @owner)
+    @permissible = FactoryBot.create(:app, custom_owner: @owner)
   end
 
   path '/permissions/users/{user_id}' do

--- a/spec/requests/permissions_spec.rb
+++ b/spec/requests/permissions_spec.rb
@@ -267,8 +267,7 @@ describe 'Permissions API' do
 
         run_test! do
           permissions = Permission.where(user: permitted_user)
-          expect(permissions.count).to eq(1)
-          expect(permissions.first.permit).to eq(Permission::NO_PERMIT_BIT)
+          expect(permissions.count).to eq(0)
         end
       end
     end

--- a/spec/requests/permissions_spec.rb
+++ b/spec/requests/permissions_spec.rb
@@ -88,7 +88,7 @@ describe 'Permissions API' do
 
         before do
           @permissible2 = FactoryBot.create(:app)
-          @permissible2.grant(user_ids: @owner.id, permit: :read)
+          @permissible2.grant_all(user_ids: @owner.id)
         end
 
         run_test! do |response|
@@ -96,13 +96,12 @@ describe 'Permissions API' do
           expect(data['user_id']).to eq(user_id)
           
           permissions = data['permissions']
-          expect(permissions.length).to eq(2)
+          expect(permissions.length).to eq(1)
           
-          expect(permissions.first['permissible_type']).to eq(@permissible.class.to_s)
-          expect(permissions.first['permissible_id']).to eq(@permissible.id)
+          expect(permissions.first['permissible_type']).to eq(@permissible2.class.to_s)
+          expect(permissions.first['permissible_id']).to eq(@permissible2.id)
 
           expect(permissions.first['permits']).to eq(Permission::PERMISSIONS_HASH.keys.map(&:to_s))
-          expect(permissions.last['permits']).to eq(['read'])
         end
       end
 
@@ -129,8 +128,9 @@ describe 'Permissions API' do
       response '200', 'Permissions retrieved successfully' do
         schema type: :resource_permission_schema
 
-        before do  
+        before do
           @permitted_user = FactoryBot.create(:user)
+          @permissible.grant_all(user_ids: user.id)
           @permissible.grant(user_ids: @permitted_user.id, permit: :read)
         end
 

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -1,77 +1,107 @@
 require 'test_helper'
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
 class AbilityTest < ActiveSupport::TestCase
-    def setup
-      @user1 = User.create!(name: 'test', email: 'test@example.test', password: 'password')
-      @user2 = User.create!(name: 'test2', email: 'test2@example.test', password: 'password2')
-      @customer = Customer.create(name: 'Acme', billing_email: 'ap@acme.com')
+  def setup
+    @user1 = User.create!(name: 'test', email: 'test@example.test', password: 'password')
+    @user2 = User.create!(name: 'test2', email: 'test2@example.test', password: 'password2')
+    @user3 = User.create!(name: 'test3', email: 'test3@example.test', password: 'password3')
+    @customer = Customer.create(name: 'Acme', billing_email: 'ap@acme.com')
 
-      @app_user1 = App.create(user: @user1, owner: @user1, descriptive_name: 'New App, User 1')
-      @manifest_user1 = Manifest.create(user: @user1, owner: @user1, app_id: '123ABC', content: "{}", internal_app_id: @app_user1.id)
+    @org1 = Organization.create(name: 'testorg1', billing_email: 'org1@example.test')
 
-      @app_user2 = App.create(user: @user2, owner: @user2, descriptive_name: 'New App, User 2')
-      @manifest_user2 = Manifest.create(user: @user2, owner: @user2, app_id: '456XYZ', content: "{}", internal_app_id: @app_user2.id)
-    end
-    # ruby -I test test/models/ability_test.rb 
+    OrgRole.create(organization: @org1, user: @user1, role: 'admin')
 
-    test 'undefined user has no apps' do
-      ability = Ability.new(nil)
-      assert_equal [], App.accessible_by(ability)
-    end
+    @app_user1 = App.create(user: @user1, owner: @user1, descriptive_name: 'New App, User 1')
+    @manifest_user1 = Manifest.create(user: @user1, owner: @user1, app_id: '123ABC', content: "{}", internal_app_id: @app_user1.id)
 
+    @app_user2 = App.create(user: @user2, owner: @user2, descriptive_name: 'New App, User 2')
+    @manifest_user2 = Manifest.create(user: @user2, owner: @user2, app_id: '456XYZ', content: "{}", internal_app_id: @app_user2.id)
+    
+    @app_user3 = App.create(user: @user3, owner: @user3, descriptive_name: 'New App, User 3')
+    @manifest_user3 = Manifest.create(user: @user3, owner: @user3, app_id: '789MNO', content: "{}", internal_app_id: @app_user3.id)
+    
+    @app_org1 = App.create(user: @user1, owner: @org1, descriptive_name: 'New App, Org 1')
+    @manifest_org1 = Manifest.create(user: @user1, owner: @org1, app_id: 'CBA321', content: "{}", internal_app_id: @app_org1.id)
 
-    test 'user has access to own apps' do
-      apps = @user1.apps
-      manifests = @user1.manifests
-      ability = Ability.new(@user1)
-      assert_equal apps, apps.accessible_by(ability)
-      assert_equal manifests, manifests.accessible_by(ability)
-    end
-
-    test 'user cannot acccess apps owned by others' do
-      ability = Ability.new(@user1)
-
-      apps = App.all
-      assert_equal @user2.apps.length, 1
-      assert_equal @user2.apps.accessible_by(ability).length, 0
-
-      manifests = Manifest.all
-      assert_equal @user2.manifests.length, 1
-      assert_equal @user2.manifests.accessible_by(ability).length, 0
-    end
-
-    test 'user can access other apps owned by the same customer account' do
-      @customer.users << @user1
-      @customer.users << @user2
-      ability = Ability.new(@user1)
-
-      apps = App.where(user_id: [@user1.id, @user2.id])
-      assert_equal apps.pluck(:id), apps.accessible_by(ability).pluck(:id)
-
-      manifests = Manifest.where(user_id: [@user1.id, @user2.id])
-      assert_equal manifests.pluck(:id).sort, manifests.accessible_by(ability).pluck(:id).sort
-    end
-
-    test 'user cannot access apps owned by a customer account they are not a member of' do
-      @customer.users << @user1
-      apps = App.accessible_by(Ability.new(@user1))
-      assert_not_includes apps.pluck(:id), @app_user2.id
-    end
-
-    test 'new user with default role has no apps' do
-      default = User.create!(name: 'default', email: 'default@example.com', password: 'password')
-      assert_not_equal default.id, nil
-      apps = App.accessible_by(Ability.new(default))
-      assert_equal [], apps.pluck(:id)
-    end
-
-
-     test 'admin can access all apps' do
-      skip("Pending support for admin abilities in UI")
-      admin = User.create!(name: 'admin', email: 'admin@example.com', password: 'password', role: 'admin')
-      assert_not_equal admin.id, nil
-      apps = App.accessible_by(Ability.new(admin))
-      assert_equal App.all.pluck(:id), apps.pluck(:id)
-    end
-
+    Permission.create(permissible: @app_user3, user: @user1, permit: Permission::READ_BIT)
+    Permission.create(permissible: @manifest_user3, user: @user1, permit: Permission::READ_BIT)
   end
+  # ruby -I test test/models/ability_test.rb 
+
+  test 'undefined user has no apps' do
+    ability = Ability.new(nil)
+    assert_equal [], App.accessible_by(ability)
+  end
+
+
+  test 'user can read any associated resources' do
+    apps = @user1.associated_apps
+    manifests = @user1.associated_manifests
+    ability = Ability.new(@user1)
+  
+    apps.each do |app|
+      assert ability.can? :read, app
+    end
+    manifests.each do |manifest|
+      assert ability.can? :read, manifest
+    end
+  end
+
+  test 'user cannot access unassociated resources' do
+    ability = Ability.new(@user1)
+
+    assert_not ability.can? :read, @app_user2
+    assert_not ability.can? :read, @manifest_user2
+  end
+
+  test 'user has all abilities for owned resources' do
+    ability = Ability.new(@user1)
+    
+    assert ability.can? :manage, @app_user1
+    assert ability.can? :grant, @app_user1
+    assert ability.can? :revoke, @app_user1
+    assert ability.can? :transfer, @app_user1
+
+    assert ability.can? :manage, @manifest_user1
+    assert ability.can? :grant, @manifest_user1
+    assert ability.can? :revoke, @manifest_user1
+    assert ability.can? :transfer, @manifest_user1
+  end
+
+  test 'user has all abilities for resources owned by orgs they are admin of' do
+    ability = Ability.new(@user1)
+    
+    assert ability.can? :manage, @app_org1
+    assert ability.can? :grant, @app_org1
+    assert ability.can? :revoke, @app_org1
+    assert ability.can? :transfer, @app_org1
+
+    assert ability.can? :manage, @manifest_org1
+    assert ability.can? :grant, @manifest_org1
+    assert ability.can? :revoke, @manifest_org1
+    assert ability.can? :transfer, @manifest_org1
+  end
+
+  test 'user only has permitted abilites for permitted resources' do
+    ability = Ability.new(@user1)
+
+    assert ability.can? :read, @app_user3
+    assert_not ability.can? :update, @app_user3
+    assert_not ability.can? :destroy, @app_user3
+    assert_not ability.can? :grant, @app_user3
+    assert_not ability.can? :revoke, @app_user3
+    assert_not ability.can? :transfer, @app_user3
+
+    assert ability.can? :read, @manifest_user3
+    assert_not ability.can? :update, @manifest_user3
+    assert_not ability.can? :destroy, @manifest_user3
+    assert_not ability.can? :grant, @manifest_user3
+    assert_not ability.can? :revoke, @manifest_user3
+    assert_not ability.can? :transfer, @manifest_user3
+
+    Permission.create(permissible: @app_user3, user: @user1, permit: Permission::GRANT_BIT)
+    Permission.create(permissible: @manifest_user3, user: @user1, permit: Permission::REVOKE_BIT)
+    assert ability.can? :grant, @app_user3
+    assert ability.can? :revoke, @manifest_user3
+  end
+end


### PR DESCRIPTION
**Before**
Authorization was based on single user association and customer scope
`revoke_all` and `revoke` left behind `NO_PERMIT_BIT`
associated resources were not collectable through a single method call

**After**
Authorization is based on Ownership, OrgRole, and Permissions
`revoke_all` and `revoke` perform full deletion
there are method calls to collect all associated resources for a user. For example: `associated_apps` or `associated_credential_sets`