### PR TITLE
fix/reset_password

### DIFF
--- a/app/controllers/overrides/passwords_controller.rb
+++ b/app/controllers/overrides/passwords_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Overrides
+  class PasswordsController < DeviseTokenAuth::PasswordsController
+    private
+
+    def redirect_options
+      {
+        allow_other_host: true
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
 
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     registrations: 'overrides/registrations',
-    sessions: 'overrides/sessions'
+    sessions: 'overrides/sessions',
+    passwords: 'overrides/passwords'
   }, skip: [:token_validations, :invitations]
 
   # only generate the manually designated routes


### PR DESCRIPTION
**Before**
Redirection to `[front-end-url]/resetpassword` during `PUT auth/password/edit` requests would error out with `ActionController::Redirecting::UnsafeRedirectError` due to an update in Rails 7

**After**
Redirection works properly

**Notes**
The Trivial-UI front-end may still need alteration to increase flexibility when delivering the `redirect_url` as a part of the `POST auth/password` request the begins the password reset flow. Currently it is hard coded and needs to be manually altered in local and staging environments