### PR TITLE
bump/puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 7.0.5.1', '>= 7.0'
 # Use sqlite3 as the database for Active Record
 # gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 4.1'
+gem 'puma', '> 6','< 7'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 7.0.5.1', '>= 7.0'
 # Use sqlite3 as the database for Active Record
 # gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '> 6.3.1','< 7'
+gem 'puma', '~> 6.3.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 7.0.5.1', '>= 7.0'
 # Use sqlite3 as the database for Active Record
 # gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '> 6','< 7'
+gem 'puma', '> 6.3.1','< 7'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     posthog-ruby (2.3.0)
       concurrent-ruby (~> 1)
     public_suffix (5.0.1)
-    puma (6.4.0)
+    puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
@@ -304,7 +304,7 @@ DEPENDENCIES
   pagy
   pg
   posthog-ruby
-  puma (> 6.3.1, < 7)
+  puma (~> 6.3.1)
   rack-cors
   rails (~> 7.0.5.1, >= 7.0)
   redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ DEPENDENCIES
   pagy
   pg
   posthog-ruby
-  puma (> 6, < 7)
+  puma (> 6.3.1, < 7)
   rack-cors
   rails (~> 7.0.5.1, >= 7.0)
   redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     posthog-ruby (2.3.0)
       concurrent-ruby (~> 1)
     public_suffix (5.0.1)
-    puma (4.3.12)
+    puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
@@ -304,7 +304,7 @@ DEPENDENCIES
   pagy
   pg
   posthog-ruby
-  puma (~> 4.1)
+  puma (> 6, < 7)
   rack-cors
   rails (~> 7.0.5.1, >= 7.0)
   redis


### PR DESCRIPTION
**Before**
Puma version was 4.3.12. Puma versions < 5.6.7 and < 6.3.1 suffer from a critical security issue related to HTTP request smuggling

**After**
Puma version bumped to 6.4.0

**Notes**
fixes #196 
No other changes needed according to repository searches and references against 
https://github.com/puma/puma/blob/master/5.0-Upgrade.md 
and 
https://github.com/puma/puma/blob/master/6.0-Upgrade.md