### PR TITLE
update/retrieve_permissions

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -4,8 +4,7 @@ class PermissionsController < ApplicationController
 
   # GET /permissions/users/:user_id
   def index_user
-    permissions = Permission.where(user: @user)
-    permissions = Permission.group_by_user(permissions)
+    permissions = Permission.permissions_for(@user)
     render json: permissions, status: :ok
   end
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -8,6 +8,41 @@ class Permission < ApplicationRecord
   validates :permissible, presence: true
   validates :permit, presence: true
 
+  def self.permissions_for(user)
+    # we only care about special permissions. read and create are excluded
+    permissions = {
+      update: {},
+      destroy: {},
+      grant: {},
+      transfer: {}
+    }
+
+    # id apps by name
+    owned_apps = user.owned_apps.pluck(:name)
+    managed_apps = App.where(owner: user.organizations.where(org_roles: { role: "admin" })).pluck(:name)
+
+    # id credential_sets by id
+    owned_credentials = user.owned_credential_sets.pluck(:id)
+    managed_credentials = CredentialSet.where(owner: user.organizations.where(org_roles: { role: "admin" })).pluck(:id)
+
+    # build the resource permission arrays and return permissions
+    permissions.each do |ability, resources|
+      permission_conditions = { user: user, permit: PERMISSIONS_HASH[ability] }
+
+      permitted_app_ids = Permission
+        .where(permission_conditions.merge(permissible_type: "App"))
+        .pluck(:permissible_id)
+      permitted_apps = App.where(id: permitted_app_ids).pluck(:name)
+
+      permitted_credentials = Permission
+        .where(permission_conditions.merge(permissible_type: "CredentialSet"))
+        .pluck(:permissible_id)
+
+      resources[:app_names] = owned_apps + managed_apps + permitted_apps
+      resources[:credential_set_ids] = owned_credentials + managed_credentials + permitted_credentials
+    end
+  end
+
   def self.group_by_user(permissions)
     permissions = permissions.group_by(&:user_id)
 


### PR DESCRIPTION
**Before**
`index_user` returned incomplete and poorly formatted permission sets based on early iterations of the permissions system

**After**
`index_user` returns an object of permissions for a given user formatted as follows:
```
{
  "update": { # ability to edit
    "app_names": [xxxxxx, yyyyyy, zzzzzz], # array of app names
    "credential_set_ids": [1, 2] # array of credential_set ids
  },  
  "destroy": { # ability to delete
    "app_names": [xxxxxx, yyyyyy, zzzzzz], # array of app names
    "credential_set_ids": [1, 2] # array of credential_set ids
  },
  "grant": { # ability to grant/revoke permissions
    "app_names": [xxxxxx, yyyyyy, zzzzzz], # array of app names
    "credential_set_ids": [1, 2] # array of credential_set ids
  },
  "transfer": { # ability to change owner
    "app_names": [xxxxxx, yyyyyy, zzzzzz], # array of app names
    "credential_set_ids": [1, 2] # array of credential_set ids
  }
}
```

**Notes**
The returned arrays are a merger of all the `resources` a `user` has that `permission` for regardless of how they obtained that `permission`. For example, a `user` may own one `app`, be an `admin` of an `organization` that owns another, and have been granted special `update` permissions for a third `app`, but all three `apps` will be displayed in the `app_names` array under `update`