### PR TITLE
feature/transfer

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,7 +1,7 @@
 class PermissionsController < ApplicationController
   before_action :set_resource, except: %i[ index_user ]
   before_action :set_user, except: %i[ index_resource transfer ]
-  before_action :set_owner, only: %i[ transfer ]
+  before_action :set_new_owner, only: %i[ transfer ]
 
   # GET /permissions/users/:user_id
   def index_user
@@ -66,7 +66,7 @@ class PermissionsController < ApplicationController
     authorize! :transfer, @permissible
     render json: { message: 'Transfer to Owner Unauthorized' }, status: :unauthorized unless authorize_transfer!
 
-    if @permissible.transfer_ownership(new_owner: @owner)
+    if @permissible.transfer_ownership(new_owner: @new_owner)
       render json: { message: 'Tranfer Ownership OK'}, status: :ok
     else
       render json: { message: 'Tranfer Ownership Failed' }, status: :unprocessable_entity
@@ -75,8 +75,8 @@ class PermissionsController < ApplicationController
 
   private
     def authorize_transfer!
-      return true if @owner == current_user
-      return false unless @owner.is_a?(Organization) && current_user.organizations.exists?(@owner)
+      return true if @new_owner == current_user
+      return false unless @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner)
       true
     end
 
@@ -96,11 +96,11 @@ class PermissionsController < ApplicationController
       @user = User.find(params[:user_id])
     end
 
-    def set_owner
+    def set_new_owner
       begin
         owner_class = params[:owner_type].classify.constantize
         owner_id = params[:owner_id]
-        @owner = owner_class.find(owner_id)
+        @new_owner = owner_class.find(owner_id)
       rescue NameError => e
         render json: { message: "#{params[:permissible_type]} Class Type Not Found" }, status: :unprocessable_entity
       end

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -98,8 +98,8 @@ class PermissionsController < ApplicationController
 
     def set_new_owner
       begin
-        owner_class = params[:owner_type].classify.constantize
-        owner_id = params[:owner_id]
+        owner_class = params[:new_owner_type].classify.constantize
+        owner_id = params[:new_owner_id]
         @new_owner = owner_class.find(owner_id)
       rescue NameError => e
         render json: { message: "#{params[:permissible_type]} Class Type Not Found" }, status: :unprocessable_entity

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -75,9 +75,8 @@ class PermissionsController < ApplicationController
 
   private
     def authorize_transfer!
-      return true if @new_owner == current_user
-      return false unless @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner)
-      true
+      return true if @new_owner == current_user # This line is necessary for allowing a user to transfer from an Organization to themselves
+      @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner)
     end
 
     # Use callback to set the resource to determine permission actions

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -64,7 +64,10 @@ class PermissionsController < ApplicationController
   # PUT permissions/:permissible_type/:permissible_id/:new_owner_type/:new_owner_id
   def transfer
     authorize! :transfer, @permissible
-    render json: { message: 'Transfer to Owner Unauthorized' }, status: :unauthorized unless authorize_transfer!
+    unless authorize_transfer!
+      render json: { message: 'Transfer to Owner Unauthorized' }, status: :unauthorized
+      return
+    end
 
     if @permissible.transfer_ownership(new_owner: @new_owner)
       render json: { message: 'Tranfer Ownership OK'}, status: :ok

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -63,7 +63,9 @@ class PermissionsController < ApplicationController
 
   # PUT permissions/:permissible_type/:permissible_id/:owner_type/:owner_id
   def transfer
-    authorize! :tranfer, @permissible
+    authorize! :transfer, @permissible
+    render json: { message: 'Transfer to Owner Unauthorized' }, status: :unauthorized unless authorize_transfer!
+
     if @permissible.transfer_ownership(new_owner: @owner)
       render json: { message: 'Tranfer Ownership OK'}, status: :ok
     else
@@ -72,6 +74,12 @@ class PermissionsController < ApplicationController
   end
 
   private
+    def authorize_transfer!
+      return true if @owner == current_user
+      return false unless @owner.is_a?(Organization) && current_user.organizations.exists?(@owner)
+      true
+    end
+
     # Use callback to set the resource to determine permission actions
     def set_resource
       begin

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -76,7 +76,7 @@ class PermissionsController < ApplicationController
   private
     def authorize_transfer!
       return true if @new_owner == current_user # This line is necessary for allowing a user to transfer from an Organization to themselves
-      @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner)
+      @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner.id)
     end
 
     # Use callback to set the resource to determine permission actions

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -61,7 +61,7 @@ class PermissionsController < ApplicationController
     end
   end
 
-  # PUT permissions/:permissible_type/:permissible_id/:owner_type/:owner_id
+  # PUT permissions/:permissible_type/:permissible_id/:new_owner_type/:new_owner_id
   def transfer
     authorize! :transfer, @permissible
     render json: { message: 'Transfer to Owner Unauthorized' }, status: :unauthorized unless authorize_transfer!

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,7 +1,7 @@
 class PermissionsController < ApplicationController
   before_action :set_resource, except: %i[ index_user ]
   before_action :set_user, except: %i[ index_resource transfer ]
-  before_action :set_owner, only %i[ transfer ]
+  before_action :set_owner, only: %i[ transfer ]
 
   # GET /permissions/users/:user_id
   def index_user
@@ -65,7 +65,7 @@ class PermissionsController < ApplicationController
   def transfer
     authorize! :tranfer, @permissible
     if @permissible.transfer_ownership(new_owner: @owner)
-      render json { message: 'Tranfer Ownership OK'}, status: :ok
+      render json: { message: 'Tranfer Ownership OK'}, status: :ok
     else
       render json: { message: 'Tranfer Ownership Failed' }, status: :unprocessable_entity
     end

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -75,7 +75,7 @@ class PermissionsController < ApplicationController
 
   private
     def authorize_transfer!
-      return true if @new_owner == current_user # This line is necessary for allowing a user to transfer from an Organization to themselves
+      return true if @new_owner == current_user # This line is necessary to allow users transferring a resource from an Organization to themselves
       @new_owner.is_a?(Organization) && current_user.organizations.exists?(@new_owner.id)
     end
 
@@ -101,7 +101,7 @@ class PermissionsController < ApplicationController
         owner_id = params[:new_owner_id]
         @new_owner = owner_class.find(owner_id)
       rescue NameError => e
-        render json: { message: "#{params[:permissible_type]} Class Type Not Found" }, status: :unprocessable_entity
+        render json: { message: "#{params[:new_owner_type]} Class Type Not Found" }, status: :unprocessable_entity
       end
     end
 

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -110,12 +110,9 @@ class App < ApplicationRecord
   def transfer_ownership(new_owner:, revoke: false)
     super(new_owner: new_owner, revoke: revoke)
 
-    activity_entries.each do |entry|
-      entry.update(owner: new_owner)
-    end
-    manifests.each do |manifest|
-      manifest.update(owner: new_owner)
-    end
+    byebug
+    manifests.update_all(owner_id: new_owner.id, owner_type: new_owner.class.name)
+    activity_entries.update_all(owner_id: new_owner.id, owner_type: new_owner.class.name)
   end
 
   private

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -110,9 +110,12 @@ class App < ApplicationRecord
   def transfer_ownership(new_owner:, revoke: false)
     super(new_owner: new_owner, revoke: revoke)
 
-    ActivityEntry.update(ActivityEntry.where(app: self).pluck(:id), owner: @owner)
-    Manifest.update(Manifest.where(app: self).pluck(:id), owner: @owner)
-    ManifestDraft.update(ManifestDraft.where(app: self).pluck(:id), owner: @owner)
+    activity_entries.each do |entry|
+      entry.update(owner: new_owner)
+    end
+    manifests.each do |manifest|
+      manifest.update(owner: new_owner)
+    end
   end
 
   private

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -106,6 +106,15 @@ class App < ApplicationRecord
     end
   end
 
+  # overwrites Ownable method
+  def transfer_ownership(new_owner:, revoke: false)
+    super(new_owner: new_owner, revoke: revoke)
+
+    ActivityEntry.update(ActivityEntry.where(app: self).pluck(:id), owner: @owner)
+    Manifest.update(Manifest.where(app: self).pluck(:id), owner: @owner)
+    ManifestDraft.update(ManifestDraft.where(app: self).pluck(:id), owner: @owner)
+  end
+
   private
 
   def credentials_name

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -110,7 +110,6 @@ class App < ApplicationRecord
   def transfer_ownership(new_owner:, revoke: false)
     super(new_owner: new_owner, revoke: revoke)
 
-    byebug
     manifests.update_all(owner_id: new_owner.id, owner_type: new_owner.class.name)
     activity_entries.update_all(owner_id: new_owner.id, owner_type: new_owner.class.name)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
   post '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#grant_all'
   delete '/permission/:permit/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke'
   delete '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke_all'
+  put '/permissions/:permissible_type/:permissible_id/:owner_type/:owner_id', to: 'permissions#transfer'
 
   get '/up', to: 'health_check#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
   post '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#grant_all'
   delete '/permission/:permit/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke'
   delete '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke_all'
-  put '/permissions/:permissible_type/:permissible_id/:owner_type/:owner_id', to: 'permissions#transfer'
+  put '/:permissible_type/:permissible_id/transfer/:new_owner_type/:new_owner_id', to: 'permissions#transfer'
 
   get '/up', to: 'health_check#show'
 end

--- a/spec/requests/permissions_spec.rb
+++ b/spec/requests/permissions_spec.rb
@@ -282,5 +282,31 @@ describe 'Permissions API' do
       end
     end
   end
+  
+  path '/{permissible_type}/{permissible_id}/transfer/{new_owner_type}/{new_owner_id}' do
+    parameter name: 'permissible_type', in: :path, type: :string
+    parameter name: 'permissible_id', in: :path, type: :integer
+    parameter name: 'new_owner_type', in: :path, type: :string
+    parameter name: 'new_owner_id', in: :path, type: :integer
+    
+    let(:permissible_type) { @app.class.to_s.tableize }
+    let(:permissible_id) { @app.id }
+    
+    let!(:new_owner) { FactoryBot.create(:organization) }
+    let(:new_owner_type) { new_owner.class.to_s.tableize }
+    let(:new_owner_id) { new_owner.id }
+    
+    put 'Transfer Ownership to Organization' do
+      tags 'Permissions'
+      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
+      produces 'permission/json'
+
+      response '200', 'Tranfer Ownership Successful' do
+        run_test! do
+          expect(@app.reload.owner).to eq(new_owner)
+        end
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
**Before**
No API interface for transferring ownership of `ownable` resources. All transfers were done through console

**After**
Added route and controller method for calls to transfer ownership of a `resource`

**Notes**
The `transfer_ownership` concern method can be overwritten within a model to provide broader functionality and drag along related resources.
Currently, this has been done with the `App` transfer method so that related `Manifest`, `ManifestDraft`, and `ActivityEntry` resources are dragged along in the transfer.

**Tasks**
- [x] Create single resource ownership transfer end-point with proper authorization
- [x] Authorization that owner can accept transfer from current owner
- [x] ~~API end-point for transferring multiple resources at once~~
- [x] Test