### PR TITLE
refactor/permissions_routes

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,6 +1,6 @@
 class PermissionsController < ApplicationController
-  before_action :set_resource, except: %i[ index_user ]
-  before_action :set_user, except: %i[ index_resource ]
+  before_action :set_resource, except: %i[ show_user ]
+  before_action :set_user, except: %i[ show_resource ]
 
   # GET /users/:user_id/permissions
   def show_user

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -2,21 +2,21 @@ class PermissionsController < ApplicationController
   before_action :set_resource, except: %i[ index_user ]
   before_action :set_user, except: %i[ index_resource ]
 
-  # GET /permissions/users/:user_id
-  def index_user
+  # GET /users/:user_id/permissions
+  def show_user
     permissions = Permission.permissions_for(@user)
     render json: permissions, status: :ok
   end
 
-  # GET /permissions/:permissible_type/:permissible_id
-  def index_resource
+  # GET /:permissible_type/:permissible_id/permissions
+  def show_resource
     authorize! :grant, @permissible
     permissions = Permission.where(permissible: @permissible)
     permissions = Permission.group_by_resource(permissions)
     render json: permissions, status: :ok
   end
 
-  # POST /permission/:permit/:permissible_type/:permissible_id/users/:user_id
+  # POST /:permissible_type/:permissible_id/permission/:permit/users/:user_id
   def grant
     authorize! :grant, @permissible
     if @permissible.grant(user_ids: @user.id, permit: params[:permit].to_sym)
@@ -28,7 +28,7 @@ class PermissionsController < ApplicationController
     end
   end
 
-  # POST /permissions/:permissible_type/:permissible_id/users/:user_id
+  # POST /:permissible_type/:permissible_id/permissions/users/:user_id
   def grant_all
     authorize! :grant, @permissible
     if @permissible.grant_all(user_ids: @user.id)
@@ -40,7 +40,7 @@ class PermissionsController < ApplicationController
     end
   end
 
-  # DELETE /permission/:permit/:permissible_type/:permissible_id/users/:user_id
+  # DELETE /:permissible_type/:permissible_id/permission/:permit/users/:user_id
   def revoke
     authorize! :revoke, @permissible
     if @permissible.revoke(user_ids: @user.id, permit: params[:permit].to_sym)
@@ -50,7 +50,7 @@ class PermissionsController < ApplicationController
     end
   end
 
-  # DELETE /permissions/:permissible_type/:permissible_id/users/:user_id
+  # DELETE /:permissible_type/:permissible_id/permissions/users/:user_id
   def revoke_all
     authorize! :revoke, @permissible
     if @permissible.revoke_all(user_ids: @user.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,12 +92,12 @@ Rails.application.routes.draw do
   delete 'credential_sets/:id', to: 'credential_sets#destroy'
   put 'credential_sets/:id/api_key', to: 'credential_sets#update_api_key'
 
-  get '/permissions/users/:user_id', to: 'permissions#index_user'
-  get '/permissions/:permissible_type/:permissible_id', to: 'permissions#index_resource'
-  post '/permission/:permit/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#grant'
-  post '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#grant_all'
-  delete '/permission/:permit/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke'
-  delete '/permissions/:permissible_type/:permissible_id/users/:user_id', to: 'permissions#revoke_all'
+  get '/users/:user_id/permissions', to: 'permissions#show_user'
+  get '/:permissible_type/:permissible_id/permissions', to: 'permissions#show_resource'
+  post '/:permissible_type/:permissible_id/permission/:permit/users/:user_id', to: 'permissions#grant'
+  post '/:permissible_type/:permissible_id/permissions/users/:user_id', to: 'permissions#grant_all'
+  delete '/:permissible_type/:permissible_id/permission/:permit/users/:user_id', to: 'permissions#revoke'
+  delete '/:permissible_type/:permissible_id/permissions/users/:user_id', to: 'permissions#revoke_all'
 
   get '/up', to: 'health_check#show'
 end

--- a/spec/requests/permissions_spec.rb
+++ b/spec/requests/permissions_spec.rb
@@ -73,7 +73,7 @@ describe 'Permissions API' do
     @app = FactoryBot.create(:app, owner: @owner)
   end
 
-  path '/permissions/users/{user_id}' do
+  path '/users/{user_id}/permissions' do
     parameter name: 'user_id', in: :path, type: :integer
     
     let(:user_id) { user.id }
@@ -122,7 +122,7 @@ describe 'Permissions API' do
     end
   end
 
-  path '/permissions/{permissible_type}/{permissible_id}' do
+  path '/{permissible_type}/{permissible_id}/permissions' do
     parameter name: 'permissible_type', in: :path, type: :string
     parameter name: 'permissible_id', in: :path, type: :integer
 
@@ -172,7 +172,7 @@ describe 'Permissions API' do
     end
   end
 
-  path '/permission/{permit}/{permissible_type}/{permissible_id}/users/{user_id}' do
+  path '/{permissible_type}/{permissible_id}/permission/{permit}/users/{user_id}' do
     parameter name: 'permit', in: :path, type: :string
     parameter name: 'permissible_type', in: :path, type: :string
     parameter name: 'permissible_id', in: :path, type: :integer
@@ -231,7 +231,7 @@ describe 'Permissions API' do
     end
   end
 
-  path '/permissions/{permissible_type}/{permissible_id}/users/{user_id}' do
+  path '/{permissible_type}/{permissible_id}/permissions/users/{user_id}' do
     parameter name: 'permissible_type', in: :path, type: :string
     parameter name: 'permissible_id', in: :path, type: :integer
     parameter name: 'user_id', in: :path, type: :integer


### PR DESCRIPTION
**Before**
Permissions `URLs` and `routes` were slightly unclear and did not closely follow REST guidelines

**After**
Permissions `URLs` and `routes` more closely follow REST guidelines on resource oriented design

**Notes**
Routes going forward will follow the general principle of having the acted upon resource first in hierarchical order for associated resources, followed by an action to be executed on that resource or resource set, and finally any resources related to executing that action.

**Examples:**

- `GET apps/3/permissions` places emphasis on the idea that `app 3` is the resource whose permissions are being asked for
- `POST credential_sets/4/permission/update/users/4` reflects the idea that we are creating a permission for `credential_set 4` with the specific permission `update` being granted to `user 4`
- `PUT organizations/3/users/4/revoke` orders resources by hierarchy showing that it is `user 4` associated under `organization 3` who is being removed from the organization. Thus the resource being acted on is still preceding the action