### PR TITLE
update/app_cloning_tags

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -96,6 +96,7 @@ class App < ApplicationRecord
     if new_app.save!
       manifest = self.manifests.order("created_at DESC").first
       manifest.copy_to_app!(new_app) if manifest
+      self.copyTagsTo(new_app)
     end
     return new_app
   end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -13,6 +13,12 @@ module Taggable
     def removeTag!(context, tag)
       self.tags.where(context: context, name: tag).delete_all
     end
+
+    def copyTagsTo(new_taggable)
+      self.tags.each do |tag|
+        new_taggable.addTag!(tag.context, tag.name)
+      end
+    end
   end
 
   class_methods do


### PR DESCRIPTION
**Before**
`Tags` were not copied with `Apps` when cloning
**After**
`App` clones now copy `Tags` as well
**Notes**
fixes #190 