### PR TITLE
Cleanup/app sharing

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -20,7 +20,6 @@ class ActivityEntriesController < ApplicationController
     authorize! :update, @app
 
     @entry = ActivityEntry.new(activity_entry_params)
-    @entry.user = current_user
     @entry.owner = current_user
     @entry.app = @app
     @entry.save!
@@ -30,7 +29,6 @@ class ActivityEntriesController < ApplicationController
   def create_from_request
     @entry = ActivityEntry.new(activity_entry_params)
     @entry.app = App.kept.find_by_name!(params[:app_id])
-    @entry.user_id = @entry.app.user_id
     @entry.owner = @entry.app.owner
     @entry.activity_type = 'request'
     @entry.normalize_json
@@ -72,7 +70,7 @@ class ActivityEntriesController < ApplicationController
   private
 
   def activity_for_index
-    attrs = [:id, :user_id, :owner_id, :owner_type, :app_id, :activity_type, :status, :duration_ms, :payload, :created_at]
+    attrs = [:id, :owner_id, :owner_type, :app_id, :activity_type, :status, :duration_ms, :payload, :created_at]
     @activity ||= app_activity.select(attrs).limit(limit).order(created_at: :desc)
   end
 

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -18,7 +18,7 @@ class ApiKeysController < ApplicationController
 
   def app(for_user = true)
     if for_user
-      @app ||= current_user.apps.kept.find_by_name!(params[:app_id])
+      @app ||= current_user.associated_apps.kept.find_by_name!(params[:app_id])
     else
       @app ||= App.kept.find_by_name!(params[:app_id])
     end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -27,7 +27,6 @@ class AppsController < ApplicationController
 
   def create
     @app = App.new(app_params)
-    @app.user = current_user
     @app.owner = current_user
     @app.save!
     render json: @app.as_json(methods: [:aws_role])

--- a/app/controllers/credential_sets_controller.rb
+++ b/app/controllers/credential_sets_controller.rb
@@ -7,7 +7,7 @@ class CredentialSetsController < ApplicationController
   end
 
   def create
-    @credential_set = current_user.credential_sets.new(credential_set_params)
+    @credential_set = CredentialSet.new(credential_set_params)
     @credential_set.owner = current_user
     @credential_set.save!
     if params.has_key?(:credentials)
@@ -55,7 +55,7 @@ class CredentialSetsController < ApplicationController
 
   def update_api_key
     @keys = ApiKeys.for_key!(auth_key)
-    @credential_set = @keys.app.user.credential_sets.find_by_external_id!(params[:id])
+    @credential_set = @keys.app.owner.owned_credential_sets.find_by_external_id!(params[:id])
     render json: {
       api_key: @keys.refresh_in_credential_set!(@credential_set, auth_key, params[:path])
     }
@@ -73,7 +73,7 @@ class CredentialSetsController < ApplicationController
   end
 
   def patchable_credential_set
-    @credential_set ||= current_app.user.associated_credential_sets.find_by_external_id!(params[:id])
+    @credential_set ||= current_app.owner.owned_credential_sets.find_by_external_id!(params[:id])
   end
 
   def credential_set_params

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -6,7 +6,6 @@ class ManifestsController < ApplicationController
 
     def create
         manifest = Manifest.new(manifest_params.merge(app: app))
-        manifest.user_id = current_user.id
         manifest.owner = current_user
         if manifest.save
             render json: manifest, adapter: :attributes, status: :created

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -5,11 +5,6 @@ class ActivityEntry < ApplicationRecord
   validates :source, presence: true, if: :is_request?
 
   belongs_to :app
-
-  # old user association to be deprecated for ownership and permissions
-  belongs_to :user
-
-  # new owner based association
   belongs_to :owner, polymorphic: true
 
   before_create :generate_update_id
@@ -49,7 +44,6 @@ class ActivityEntry < ApplicationRecord
   def legacy_attributes
     {
       id: self.id,
-      user_id: self.user_id,
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
@@ -67,7 +61,6 @@ class ActivityEntry < ApplicationRecord
   def activity_attributes
     {
       id: self.id,
-      user_id: self.user_id,
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
@@ -85,7 +78,6 @@ class ActivityEntry < ApplicationRecord
   def activity_attributes_for_index
     {
       id: self.id,
-      user_id: self.user_id,
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
@@ -125,45 +117,45 @@ class ActivityEntry < ApplicationRecord
   end
 
   def self.chart_stats(app_id, number_of_days)
-      return self.get_chart_stats(app_id,number_of_days)
+    return self.get_chart_stats(app_id,number_of_days)
   end
 
   private
 
   def self.get_chart_stats(app_id, number_of_days)
-      stats = ActivityEntry.requests.where("app_id = ? AND created_at > ?", app_id, number_of_days.days.ago).group("DATE_TRUNC('day', created_at)").group(:status).count(:all)
-      self.format_chart_stats(stats, number_of_days)
+    stats = ActivityEntry.requests.where("app_id = ? AND created_at > ?", app_id, number_of_days.days.ago).group("DATE_TRUNC('day', created_at)").group(:status).count(:all)
+    self.format_chart_stats(stats, number_of_days)
   end
 
   def self.format_chart_stats(stats, number_of_days)
-      chart_stats = []
-      (0..number_of_days-1).each {|i|
-          key = Time.parse((Date.today - i.days).to_s)
-          count = self.webhook_by_date(i, stats, key)
-          if count.empty?
-              chart_stats.push({
-                  date: key.strftime("%m/%d/%Y"),
-                  count: {}
-              })
-          else
-              count_concat = {}
-              count.keys.each do |c|
-                  count_concat[c.second] = count[c]
-              end
-              chart_stats.push({
-                  date: key.strftime("%m/%d/%Y"),
-                  count: count_concat
-              })
-          end
-      }
-      return chart_stats
+    chart_stats = []
+    (0..number_of_days-1).each {|i|
+      key = Time.parse((Date.today - i.days).to_s)
+      count = self.webhook_by_date(i, stats, key)
+      if count.empty?
+        chart_stats.push({
+          date: key.strftime("%m/%d/%Y"),
+          count: {}
+        })
+      else
+        count_concat = {}
+        count.keys.each do |c|
+          count_concat[c.second] = count[c]
+        end
+        chart_stats.push({
+          date: key.strftime("%m/%d/%Y"),
+          count: count_concat
+        })
+      end
+    }
+    return chart_stats
   end
 
   def self.webhook_by_date(index, stats, key)
-      count = stats.select{ |w|
-          ws = w[0].strftime("%Y-%m-%d");
-          ks = key.strftime("%Y-%m-%d");
-          ws == ks
-      }
+    count = stats.select{ |w|
+      ws = w[0].strftime("%Y-%m-%d");
+      ks = key.strftime("%Y-%m-%d");
+      ws == ks
+    }
   end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -142,6 +142,7 @@ class App < ApplicationRecord
       AND date_trunc(#{connection.quote interval_name}, w.created_at) <= #{connection.quote until_time}
     WHERE
       a.owner_id = #{connection.quote user.id}
+      AND a.owner_type = 'User'
       AND a.discarded_at IS NULL
     GROUP BY a.id, a.name, a.descriptive_name, period, last_run
     ORDER BY a.descriptive_name, a.id, period

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -7,16 +7,9 @@ class App < ApplicationRecord
 
   MINIMUM_PORT_NUMBER = 3001
 
-  # old user association to be deprecated for ownership and permissions
-  belongs_to :user
-
-  # new owner based association
   belongs_to :owner, polymorphic: true
-
-  # new permission based multi-user association
   has_many :permissions, as: :permissible
   has_many :permitted_users, through: :permissions, source: :user
-  
   has_many :manifests, foreign_key: :internal_app_id, inverse_of: :app
   has_many :activity_entries, inverse_of: :app
   has_many :tags, as: :taggable
@@ -33,9 +26,7 @@ class App < ApplicationRecord
 
   def descriptive_name_unique?
     # custom validator to factor for deleted apps
-    if user
-      unique = user.apps.kept.where(descriptive_name: descriptive_name).where.not(id: id).size == 0
-    elsif owner
+    if owner
       unique = owner.owned_apps.kept.where(descriptive_name: descriptive_name).where.not(id: id).size == 0
     else 
       return false
@@ -51,8 +42,9 @@ class App < ApplicationRecord
     base.to_s
   end
 
+  # returns nil for Organization owners
   def aws_role
-    user.ensure_aws_role!
+    owner.try(:ensure_aws_role!)
   end
 
   def credentials
@@ -90,7 +82,6 @@ class App < ApplicationRecord
   def copy!(new_user=nil, descriptive_name)
     new_app = self.dup
     new_app.unset_defaults
-    new_app.user = new_user if new_user
     new_app.owner = new_user if new_user
     new_app.descriptive_name = descriptive_name
     if new_app.save!
@@ -147,7 +138,7 @@ class App < ApplicationRecord
       AND date_trunc(#{connection.quote interval_name}, w.created_at) >= #{connection.quote since_time}
       AND date_trunc(#{connection.quote interval_name}, w.created_at) <= #{connection.quote until_time}
     WHERE
-      a.user_id = #{connection.quote user.id}
+      a.owner_id = #{connection.quote user.id}
       AND a.discarded_at IS NULL
     GROUP BY a.id, a.name, a.descriptive_name, period, last_run
     ORDER BY a.descriptive_name, a.id, period
@@ -176,5 +167,4 @@ class App < ApplicationRecord
 
     {start_range: since_time, end_range: until_time, stats: out}
   end
-
 end

--- a/app/models/credential_set.rb
+++ b/app/models/credential_set.rb
@@ -2,13 +2,7 @@ class CredentialSet < ApplicationRecord
   include Ownable
   include Permissible
 
-  # old user association to be deprecated for ownership and permissions
-  belongs_to :user, inverse_of: :credential_sets
-  
-  # new owner based association
   belongs_to :owner, polymorphic: true
-  
-  # new permission based multi-user association
   has_many :permissions, as: :permissible
   has_many :permitted_users, through: :permissions, source: :user
 
@@ -17,7 +11,7 @@ class CredentialSet < ApplicationRecord
   before_create :set_external_id
 
   def credentials
-    @credentials ||= CredentialSetCredentials.find_or_build_by_user_and_name user, credentials_name
+    @credentials ||= CredentialSetCredentials.find_or_build_by_user_and_name owner, credentials_name
   end
 
   def api_attrs
@@ -39,5 +33,4 @@ class CredentialSet < ApplicationRecord
   def set_external_id
     self.external_id = SecureRandom.uuid
   end
-
 end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -2,18 +2,10 @@ class Manifest < ApplicationRecord
     include Ownable
     include Permissible
     validates :app_id, presence: true
-    validates :user_id, presence: true
     validates :content, presence: true
 
     belongs_to :app, foreign_key: :internal_app_id, inverse_of: :manifests
-    
-    # old user association to be deprecated for ownership and permissions
-    belongs_to :user
-    
-    # new owner based association
     belongs_to :owner, polymorphic: true
-    
-    # new permission based multi-user association
     has_many :permissions, as: :permissible
     has_many :permitted_users, through: :permissions, source: :user
 
@@ -22,7 +14,6 @@ class Manifest < ApplicationRecord
     def copy_to_app!(new_app)
         new_manifest = self.dup
         new_manifest.app_id = new_app.name
-        new_manifest.user_id = new_app.user_id
         new_manifest.owner = new_app.owner
         new_manifest.internal_app_id = new_app.id
         new_manifest.set_content_app_id

--- a/app/models/manifest_draft.rb
+++ b/app/models/manifest_draft.rb
@@ -4,14 +4,7 @@ class ManifestDraft < ApplicationRecord
 
   belongs_to :app
   belongs_to :manifest
-  
-  # old user association to be deprecated for ownership and permissions
-  belongs_to :user, inverse_of: :manifest_drafts
-  
-  # new owner based association
   belongs_to :owner, polymorphic: true, inverse_of: :manifest_drafts
-
-  # new permission based multi-user association
   has_many :permissions, as: :permissible
   has_many :permitted_users, through: :permissions, source: :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,22 +11,12 @@ class User < ActiveRecord::Base
   has_many :org_roles, :dependent => :destroy
   has_many :organizations, through: :org_roles
   
-  ASSOCIATED_RESOURCES = ['apps', 'credential_sets', 'manifests', 'manifest_drafts']
-  # to be deprecated associations upon ownership transfer
-  has_many :apps
-  has_many :manifests
-  has_many :manifest_drafts
-  has_many :activity_entries
-  has_many :credential_sets
-  
-  # new ownership associations
   has_many :owned_apps, class_name: 'App', as: :owner
   has_many :owned_manifests, class_name: 'Manifest', as: :owner
   has_many :owned_manifest_drafts, class_name: 'ManifestDraft', as: :owner
   has_many :owned_activity_entries, class_name: 'ActivityEntry', as: :owner
   has_many :owned_credential_sets, class_name: 'CredentialSet', as: :owner
   
-  # new permission based associations
   has_many :permissions
   has_many :permitted_apps, -> { distinct }, through: :permissions, source: :permissible, source_type: 'App'
   has_many :permitted_manifests, -> { distinct }, through: :permissions, source: :permissible, source_type: 'Manifest'

--- a/app/serializers/app_serializer.rb
+++ b/app/serializers/app_serializer.rb
@@ -3,7 +3,7 @@ class AppSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
   attributes  :id, :name, :descriptive_name, :hostname, :domain, :load_balancer, :panels, :readable_by,
-              :schedule, :aws_role, :created_at, :updated_at, :manifest, :tags
+              :schedule, :aws_role, :created_at, :updated_at, :owner_id, :owner_type, :manifest, :tags
 
   def manifest
     return {} if object.manifests.size == 0

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -2,7 +2,7 @@ class ManifestSerializer < ActiveModel::Serializer
 
   include Rails.application.routes.url_helpers
 
-  attributes :id, :app_id, :bundle_url, :content, :user_id, :owner_id, :owner_type, :created_at, :updated_at
+  attributes :id, :app_id, :bundle_url, :content, :owner_id, :owner_type, :created_at, :updated_at
 
   def bundle_url
     rails_blob_url(object.bundle, disposition: "attachment")

--- a/db/migrate/20240108182428_remove_user_from_models.rb
+++ b/db/migrate/20240108182428_remove_user_from_models.rb
@@ -1,0 +1,21 @@
+class RemoveUserFromModels < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :apps, :users
+    remove_index :apps, :user_id
+    remove_column :apps, :user_id, :integer
+
+    remove_column :manifests, :user_id, :integer
+    
+    remove_foreign_key :manifest_drafts, :users
+    remove_index :manifest_drafts, :user_id
+    remove_column :manifest_drafts, :user_id, :integer
+    
+    remove_foreign_key :activity_entries, :users
+    remove_index :activity_entries, :user_id
+    remove_column :activity_entries, :user_id, :integer
+    
+    remove_foreign_key :credential_sets, :users
+    remove_index :credential_sets, :user_id
+    remove_column :credential_sets, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_08_182428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
   end
 
   create_table "activity_entries", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "app_id"
     t.uuid "update_id"
     t.string "activity_type", null: false
@@ -60,11 +59,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
     t.index ["app_id"], name: "index_activity_entries_on_app_id"
     t.index ["owner_type", "owner_id"], name: "index_activity_entries_on_owner"
     t.index ["update_id"], name: "index_activity_entries_on_update_id"
-    t.index ["user_id"], name: "index_activity_entries_on_user_id"
   end
 
   create_table "apps", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.string "name", null: false
     t.integer "port", null: false
     t.datetime "created_at", null: false
@@ -83,12 +80,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
     t.index ["name"], name: "index_apps_on_name", unique: true
     t.index ["owner_type", "owner_id"], name: "index_apps_on_owner"
     t.index ["port"], name: "index_apps_on_port", unique: true
-    t.index ["user_id"], name: "index_apps_on_user_id"
   end
 
   create_table "credential_sets", force: :cascade do |t|
     t.uuid "external_id", null: false
-    t.bigint "user_id", null: false
     t.string "name", null: false
     t.string "credential_type", null: false
     t.datetime "created_at", null: false
@@ -97,7 +92,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
     t.bigint "owner_id"
     t.index ["external_id"], name: "index_credential_sets_on_external_id", unique: true
     t.index ["owner_type", "owner_id"], name: "index_credential_sets_on_owner"
-    t.index ["user_id"], name: "index_credential_sets_on_user_id"
   end
 
   create_table "customers", force: :cascade do |t|
@@ -116,7 +110,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
   end
 
   create_table "manifest_drafts", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "app_id", null: false
     t.bigint "manifest_id", null: false
     t.jsonb "content"
@@ -131,13 +124,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
     t.index ["manifest_id"], name: "index_manifest_drafts_on_manifest_id"
     t.index ["owner_type", "owner_id"], name: "index_manifest_drafts_on_owner"
     t.index ["token"], name: "index_manifest_drafts_on_token", unique: true
-    t.index ["user_id"], name: "index_manifest_drafts_on_user_id"
   end
 
   create_table "manifests", force: :cascade do |t|
     t.string "app_id"
     t.jsonb "content"
-    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "internal_app_id"
@@ -225,12 +216,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_172505) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_entries", "apps"
-  add_foreign_key "activity_entries", "users"
-  add_foreign_key "apps", "users"
-  add_foreign_key "credential_sets", "users"
   add_foreign_key "manifest_drafts", "apps"
   add_foreign_key "manifest_drafts", "manifests"
-  add_foreign_key "manifest_drafts", "users"
   add_foreign_key "manifests", "apps", column: "internal_app_id"
   add_foreign_key "org_roles", "organizations"
   add_foreign_key "org_roles", "users"

--- a/spec/factories/activity_entry.rb
+++ b/spec/factories/activity_entry.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
 
   factory :activity_entry do
-    association :user, factory: :user
     association :owner, factory: :user
     app { FactoryBot.create(:app, user: user) }
   end

--- a/spec/factories/app.rb
+++ b/spec/factories/app.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
 
   factory :app do
-    association :user, factory: :user
     association :owner, factory: :user
     sequence(:descriptive_name) {|n| "Test App \##{n}"}
 

--- a/spec/factories/credential_set.rb
+++ b/spec/factories/credential_set.rb
@@ -1,18 +1,9 @@
 FactoryBot.define do
 
   factory :credential_set do
-    association :user, factory: :user
     association :owner, factory: :user
     name { 'Twilio' }
     credential_type { 'TwilioCredentials' }
-
-    transient do
-      custom_owner { nil }
-    end
-
-    before(:create) do |credential, evaluator|
-      credential.owner = evaluator.custom_owner if evaluator.custom_owner
-    end
 
     trait :org_owner do
       association :owner, factory: :organization

--- a/spec/factories/manifest.rb
+++ b/spec/factories/manifest.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :manifest do
     content { '{}'}
-    association :user, factory: :user
     association :owner, factory: :user
     association :app, factory: :app
 

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -4,10 +4,10 @@ describe App do
 
   describe "#daily_stats" do
     let(:user) { FactoryBot.create(:user, :logged_in, role: :admin) }
-    let(:user_app) { FactoryBot.create(:app, user: user) }
-    let!(:success1) { FactoryBot.create(:activity_entry, :request, user: user, app: user_app) }
-    let!(:success2) { FactoryBot.create(:activity_entry, :request, user: user, app: user_app) }
-    let!(:failure1) { FactoryBot.create(:activity_entry, :request, user: user, app: user_app, status: '404') }
+    let(:user_app) { FactoryBot.create(:app, owner: user) }
+    let!(:success1) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
+    let!(:success2) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
+    let!(:failure1) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app, status: '404') }
     let(:stats) { App.daily_stats(user)[:stats].first[:stats] }
 
     it "returns a summary count of activity for the day" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,8 +6,8 @@ describe User do
   let(:org) { FactoryBot.create(:organization, admin: user, members_count: 1) }
 
   describe '#associated_apps' do
-    let(:user_app) { FactoryBot.create(:app, custom_owner: user) }
-    let(:org_app) { FactoryBot.create(:app, custom_owner: org) }
+    let(:user_app) { FactoryBot.create(:app, owner: user) }
+    let(:org_app) { FactoryBot.create(:app, owner: org) }
     let(:permitted_app) { FactoryBot.create(:app) }
     let!(:unrelated_app) { FactoryBot.create(:app) }
   
@@ -40,8 +40,8 @@ describe User do
   end
 
     describe '#associated_credential_sets' do
-    let(:user_credential) { FactoryBot.create(:credential_set, custom_owner: user) }
-    let(:org_credential) { FactoryBot.create(:credential_set, custom_owner: org) }
+    let(:user_credential) { FactoryBot.create(:credential_set, owner: user) }
+    let(:org_credential) { FactoryBot.create(:credential_set, owner: org) }
     let(:permitted_credential) { FactoryBot.create(:credential_set) }
     let!(:unrelated_credential) { FactoryBot.create(:credential_set) }
   

--- a/spec/requests/activity_entries_spec.rb
+++ b/spec/requests/activity_entries_spec.rb
@@ -9,7 +9,7 @@ describe 'Activity Entries API' do
   let(:client) { user.tokens.keys.first }
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
-  let!(:user_app) { FactoryBot.create(:app, user: user, owner: user) }
+  let!(:user_app) { FactoryBot.create(:app, owner: user) }
 
   def self.activity_schema
     {
@@ -36,8 +36,8 @@ describe 'Activity Entries API' do
 
       let(:app_id) { user_app.name }
       let(:limit) { 10 }
-      let!(:build_entry) { FactoryBot.create(:activity_entry, :build, user: user, owner: user, app: user_app) }
-      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, user: user, owner: user, app: user_app) }
+      let!(:build_entry) { FactoryBot.create(:activity_entry, :build, owner: user, app: user_app) }
+      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
 
       response '200', 'Activity listing returned' do
         schema type: :array, items: activity_schema

--- a/spec/requests/api_keys_spec.rb
+++ b/spec/requests/api_keys_spec.rb
@@ -9,7 +9,7 @@ describe 'API Key API' do
     parameter name: :id, in: :path, type: :string
 
     let(:id) { user_app.name }
-    let(:user_app) { FactoryBot.create(:app, user: user, owner: user) }
+    let(:user_app) { FactoryBot.create(:app, owner: user) }
     let(:user) { FactoryBot.create(:user, :logged_in) }
 
     post 'Obtain a new API key' do

--- a/spec/requests/credential_sets_spec.rb
+++ b/spec/requests/credential_sets_spec.rb
@@ -11,7 +11,7 @@ describe 'Credential Sets API' do
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
 
-  let!(:existing_credential) { FactoryBot.create(:credential_set, user: user, owner: user) }
+  let!(:existing_credential) { FactoryBot.create(:credential_set, owner: user) }
 
   def self.credential_definition_schema
     {
@@ -217,7 +217,7 @@ describe 'Credential Sets API' do
 
       let(:Authorization) { "Bearer #{key}" }
       let(:key) { user_app.api_keys.issue! }
-      let(:user_app) { FactoryBot.create(:app, user: user) }
+      let(:user_app) { FactoryBot.create(:app, owner: user) }
       let(:path) { ['code_grant', 'access_token'] }
       let(:current_value) { 'Whe8Y5poyQo=' }
       let(:new_value) { 'zTeYlkd9yzo=' }
@@ -288,7 +288,7 @@ describe 'Credential Sets API' do
 
       let(:Authorization) { "Bearer #{key}" }
       let(:key) { user_app.api_keys.issue! }
-      let(:user_app) { FactoryBot.create(:app, user: user) }
+      let(:user_app) { FactoryBot.create(:app, owner: user) }
       let(:stored_path) { {path: 'api_key'} }
       let(:stored_key) { key }
       let(:stored_credentials) { "{\"api_key\":\"#{stored_key}\"}" }

--- a/spec/requests/manifests_spec.rb
+++ b/spec/requests/manifests_spec.rb
@@ -9,7 +9,7 @@ describe 'manifests', type: :request do
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
 
-  let!(:user_app) { FactoryBot.create(:app, custom_owner: user ) }
+  let!(:user_app) { FactoryBot.create(:app, owner: user ) }
   let!(:user_manifest) { FactoryBot.create(:manifest, custom_app: user_app) }
 
   path '/manifests?app_id={appId}' do
@@ -149,10 +149,6 @@ describe 'manifests', type: :request do
         let('access-token') { 'invalid-token' }
         run_test!
       end
-
-
     end
-
-
   end
 end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -9,7 +9,7 @@ describe 'Webhooks API' do
   let(:client) { user.tokens.keys.first }
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
-  let!(:user_app) { FactoryBot.create(:app, user: user, owner: user) }
+  let!(:user_app) { FactoryBot.create(:app, owner: user) }
 
   def self.webhook_schema
     {
@@ -60,8 +60,8 @@ describe 'Webhooks API' do
 
       let(:app_id) { user_app.name }
       let(:limit) { 10 }
-      let!(:build_entry) { FactoryBot.create(:activity_entry, :build, user: user, owner: user, app: user_app) }
-      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, user: user, owner: user, app: user_app) }
+      let!(:build_entry) { FactoryBot.create(:activity_entry, :build, owner: user, app: user_app) }
+      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
 
       response '200', 'Request listing returned' do
         schema type: :array, items: webhook_schema_for_index
@@ -126,7 +126,7 @@ describe 'Webhooks API' do
       produces 'application/json'
       parameter name: "webhookId", in: :path, type: :string
 
-      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, user: user, app: user_app) }
+      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
       let(:webhookId) { request_entry.id }
 
       response '200', 'Request log details returned' do
@@ -145,7 +145,7 @@ describe 'Webhooks API' do
       produces 'application/json'
       parameter name: "webhookId", in: :path, type: :string
 
-      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, user: user, owner: user, app: user_app, status: nil, diagnostics: nil, duration_ms: nil) }
+      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app, status: nil, diagnostics: nil, duration_ms: nil) }
       let(:webhookId) { request_entry.update_id }
 
       parameter name: :webhook_properties, in: :body, schema: {
@@ -232,7 +232,7 @@ describe 'Webhooks API' do
       produces 'application/json'
       parameter name: "webhookId", in: :path, type: :string
 
-      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, user: user, owner: user, app: user_app) }
+      let!(:request_entry) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
       let(:webhookId) { request_entry.id }
 
       response '200', 'Request re-sent' do

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -11,17 +11,17 @@ class AbilityTest < ActiveSupport::TestCase
 
     OrgRole.create(organization: @org1, user: @user1, role: 'admin')
 
-    @app_user1 = App.create(user: @user1, owner: @user1, descriptive_name: 'New App, User 1')
-    @manifest_user1 = Manifest.create(user: @user1, owner: @user1, app_id: '123ABC', content: "{}", internal_app_id: @app_user1.id)
+    @app_user1 = App.create(owner: @user1, descriptive_name: 'New App, User 1')
+    @manifest_user1 = Manifest.create(owner: @user1, app_id: '123ABC', content: "{}", internal_app_id: @app_user1.id)
 
-    @app_user2 = App.create(user: @user2, owner: @user2, descriptive_name: 'New App, User 2')
-    @manifest_user2 = Manifest.create(user: @user2, owner: @user2, app_id: '456XYZ', content: "{}", internal_app_id: @app_user2.id)
+    @app_user2 = App.create(owner: @user2, descriptive_name: 'New App, User 2')
+    @manifest_user2 = Manifest.create(owner: @user2, app_id: '456XYZ', content: "{}", internal_app_id: @app_user2.id)
     
-    @app_user3 = App.create(user: @user3, owner: @user3, descriptive_name: 'New App, User 3')
-    @manifest_user3 = Manifest.create(user: @user3, owner: @user3, app_id: '789MNO', content: "{}", internal_app_id: @app_user3.id)
+    @app_user3 = App.create(owner: @user3, descriptive_name: 'New App, User 3')
+    @manifest_user3 = Manifest.create(owner: @user3, app_id: '789MNO', content: "{}", internal_app_id: @app_user3.id)
     
-    @app_org1 = App.create(user: @user1, owner: @org1, descriptive_name: 'New App, Org 1')
-    @manifest_org1 = Manifest.create(user: @user1, owner: @org1, app_id: 'CBA321', content: "{}", internal_app_id: @app_org1.id)
+    @app_org1 = App.create(owner: @org1, descriptive_name: 'New App, Org 1')
+    @manifest_org1 = Manifest.create(owner: @org1, app_id: 'CBA321', content: "{}", internal_app_id: @app_org1.id)
 
     Permission.create(permissible: @app_user3, user: @user1, permit: Permission::READ_BIT)
     Permission.create(permissible: @manifest_user3, user: @user1, permit: Permission::READ_BIT)

--- a/test/models/activity_entry_test.rb
+++ b/test/models/activity_entry_test.rb
@@ -3,8 +3,7 @@ require 'test_helper'
 class ActivityEntryTest < ActiveSupport::TestCase
   def setup
     @app = App.new
-    @app.user = User.create(name: 'bilbo', email: 'bilbo@example.test', password: '12345678')
-    @app.owner = @app.user
+    @app.owner = User.create(name: 'bilbo', email: 'bilbo@example.test', password: '12345678')
     @app.descriptive_name = "Bilbo's App"
     @app.save!
 
@@ -12,8 +11,7 @@ class ActivityEntryTest < ActiveSupport::TestCase
     @entry.app = @app
     @entry.activity_type = 'request'
     @entry.source = 'sample'
-    @entry.user = @app.user
-    @entry.owner = @app.user
+    @entry.owner = @app.owner
     @entry.save!
   end
 
@@ -35,10 +33,10 @@ class ActivityEntryTest < ActiveSupport::TestCase
     assert_equal @entry.errors[:source], ["can't be blank"]
   end
 
-  test 'invalid without user_id' do
-    @entry.user_id = nil
+  test 'invalid without owner_id' do
+    @entry.owner_id = nil
     @entry.valid?
 
-    assert_equal @entry.errors[:user], ["must exist"]
+    assert_equal @entry.errors[:owner], ["must exist"]
   end
 end

--- a/test/models/app_test.rb
+++ b/test/models/app_test.rb
@@ -4,8 +4,8 @@ class AppTest < ActiveSupport::TestCase
     def setup
       @user = User.create!(name: 'test', email: 'test@example.test', password: 'password')
       @user2 = User.create!(name: 'test2', email: 'test2@example.test', password: 'password2')
-      @existing = App.create!(user: @user, owner: @user, descriptive_name: 'Existing App')
-      @app = App.new(user: @user, owner: @user, descriptive_name: 'New App')
+      @existing = App.create!(owner: @user, descriptive_name: 'Existing App')
+      @app = App.new(owner: @user, descriptive_name: 'New App')
     end
 
     test 'passes validation with all required files' do
@@ -22,8 +22,8 @@ class AppTest < ActiveSupport::TestCase
       assert @app.port >= App::MINIMUM_PORT_NUMBER
     end
 
-    test 'invalid without user' do
-        @app.user_id = nil
+    test 'invalid without owner' do
+        @app.owner_id = nil
         assert ! @app.valid?
     end
 
@@ -52,13 +52,13 @@ class AppTest < ActiveSupport::TestCase
 
     test 'valid with duplicate descriptive across users' do
       @app.descriptive_name = @existing.descriptive_name
-      @app.user = @user2
+      @app.owner = @user2
       assert @app.valid?
     end
 
     test 'assigns different roles to apps under different users' do
       Role.stub :create!, -> (n) { Role.new(name: n[:name], arn: "arn:x:#{n[:name]}") } do
-        @other_app = App.new(user: @user2, descriptive_name: 'Other App')
+        @other_app = App.new(owner: @user2, descriptive_name: 'Other App')
         assert_not_equal @app.aws_role, @other_app.aws_role
       end
     end
@@ -67,17 +67,17 @@ class AppTest < ActiveSupport::TestCase
       new_app = @app.copy!(nil, @app.descriptive_name + ' Copy')
       new_app.valid?
       assert_not_equal @app.name, new_app.name
-      assert_equal @app.user, new_app.user
+      assert_equal @app.owner, new_app.owner
     end
 
     test 'copies into new user account' do
       new_app = @app.copy!(@user2, @app.descriptive_name + ' Copy')
       new_app.valid?
-      assert_equal new_app.user, @user2
+      assert_equal new_app.owner, @user2
     end
 
     test 'copy includes manifest' do
-      manifest = Manifest.new(app_id: @existing.name, internal_app_id: @existing.id, user_id: @user.id, owner: @user, content: {app_id: @existing.name}.to_json)
+      manifest = Manifest.new(app_id: @existing.name, internal_app_id: @existing.id, owner: @user, content: {app_id: @existing.name}.to_json)
       assert manifest.valid?
       @existing.manifests << manifest
       @existing.save!

--- a/test/models/credentials_test.rb
+++ b/test/models/credentials_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CredentialsTest < ActiveSupport::TestCase
   def setup
     @user = User.create!(name: 'test', email: 'test@example.test', password: 'password')
-    @app = App.create!(user: @user, owner: @user, descriptive_name: 'App')
+    @app = App.create!(owner: @user, descriptive_name: 'App')
   end
 
   test 'grants permission to the app\'s role' do

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -5,9 +5,8 @@ class ManifestTest < ActiveSupport::TestCase
         @manifest = Manifest.new
         @manifest.app_id = 'BrownShirt'
         @manifest.content = '{"x":1}'
-        @manifest.user = User.create(name: 'bilbo', email: 'test@gmail.com', password: '12345678')
-        @manifest.owner = @manifest.user
-        @manifest.app = App.create(user: @manifest.user, owner: @manifest.user, name: 'BrownShirt')
+        @manifest.owner = User.create(name: 'bilbo', email: 'test@gmail.com', password: '12345678')
+        @manifest.app = App.create(owner: @manifest.owner, name: 'BrownShirt')
         @manifest.save!
         @user2 = User.create(name: 'gandolf', email: 'gandolf@gmail.com', password: '12345678')
     end
@@ -30,11 +29,11 @@ class ManifestTest < ActiveSupport::TestCase
         assert_equal @manifest.errors[:content], ["can't be blank"]
     end
 
-    test 'invalid without user_id' do
-        @manifest.user_id = nil
+    test 'invalid without owner_id' do
+        @manifest.owner_id = nil
         @manifest.valid?
 
-        assert_equal @manifest.errors[:user_id], ["can't be blank"]
+        assert_equal @manifest.errors[:owner], ["must exist"]
     end
 
     test 'content app id updates to app_id' do
@@ -45,14 +44,11 @@ class ManifestTest < ActiveSupport::TestCase
 
     test 'copy_to_app! updates app and user' do
         new_app = App.new(descriptive_name: "Hold Steady")
-        new_app.user = @user2
         new_app.owner = @user2
         new_app.save!
 
         new_manifest = @manifest.copy_to_app!(new_app)
-        assert_equal new_manifest.user, @user2
+        assert_equal new_manifest.owner, @user2
         assert_equal new_manifest.app, new_app
-
     end
-
 end


### PR DESCRIPTION
**Before**
Deprecated `user` association for `App`, `Manifest`, `ManifestDraft`, `ActivityEntry`, and `CredentialSet` models still existed
Tests not updated to reflect this deprecation
**After**
`user` association has been removed from all related models with a few related patches to reflect current functionality
**Notes**
This cleanup includes a destructive migration that leaves `user_id` data irrecoverable on rollback