### PR TITLE
fix/client_resources

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,24 +100,24 @@ class User < ActiveRecord::Base
 
   private
 
-  def associated_resources(resource_type, roles=['admin', 'member'])
+  def associated_resources(resource_type, org_roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
 
     return model_class.all if self.role == 'client'
 
-    orgs = self.organizations.where(org_roles: { role: roles })
+    orgs = self.organizations.where(org_roles: { role: org_roles })
     membership_associated = model_class.where(owner: [self] + orgs)
     permitted = model_class.where(id: self.send("permitted_#{resource_type}").pluck(:id))
 
     membership_associated.or(permitted)
   end
 
-  def associated_resources_via_app(resource_type, roles=['admin', 'member'])
+  def associated_resources_via_app(resource_type, org_roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
     
     return model_class.all if self.role == 'client'
 
-    orgs = self.organizations.where(org_roles: { role: roles })
+    orgs = self.organizations.where(org_roles: { role: org_roles })
     membership_associated = model_class.where(app: App.where(owner: [self] + orgs))
     permitted = model_class.where(app: App.where(id: self.permitted_apps.pluck(:id)))
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,8 @@ class User < ActiveRecord::Base
   def associated_resources(resource_type, roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
 
+    return model_class.all if self.role == 'client'
+
     orgs = self.organizations.where(org_roles: { role: roles })
     membership_associated = model_class.where(owner: [self] + orgs)
     permitted = model_class.where(id: self.send("permitted_#{resource_type}").pluck(:id))
@@ -112,6 +114,8 @@ class User < ActiveRecord::Base
 
   def associated_resources_via_app(resource_type, roles=['admin', 'member'])
     model_class = resource_type.classify.constantize
+    
+    return model_class.all if self.role == 'client'
 
     orgs = self.organizations.where(org_roles: { role: roles })
     membership_associated = model_class.where(app: App.where(owner: [self] + orgs))


### PR DESCRIPTION
**Before**
`client` user's resource associations were broken and returned null after PR #187 

**After**
`client` user now has full access to resources

**Notes**
None