### PR TITLE
fix/user_registration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ActiveRecord::Base
   end
 
   def active_for_authentication?
-    ensure_aws_role!
+    ensure_aws_role! if aws_env_set?
     super
   end
 
@@ -99,6 +99,13 @@ class User < ActiveRecord::Base
 
 
   private
+  def aws_env_set?
+    return false if ENV['LAMBDA_POLICY_ARN'].blank?
+    return false if ENV['AWS_REGION'].blank?
+    return false if ENV['AWS_ACCESS_KEY_ID'].blank?
+    return false if ENV['AWS_SECRET_ACCESS_KEY'].blank?
+    true
+  end
 
   def associated_resources(resource_type, org_roles=['admin', 'member'])
     model_class = resource_type.classify.constantize

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,13 +44,14 @@ class User < ActiveRecord::Base
   before_create :set_trial_expires_at
 
   def ensure_aws_role!
+    return unless aws_env_set?
     name = "#{ENV['AWS_ROLE_PREFIX'] || ''}lambda-ex-#{id.to_s(36)}"
     update!(aws_role: Role.create!(name: name).arn) if aws_role.blank?
     aws_role
   end
 
   def active_for_authentication?
-    ensure_aws_role! if aws_env_set?
+    ensure_aws_role!
     super
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
   before_create :set_trial_expires_at
 
   def ensure_aws_role!
-    return unless aws_env_set?
+    return "" unless aws_env_set?
     name = "#{ENV['AWS_ROLE_PREFIX'] || ''}lambda-ex-#{id.to_s(36)}"
     update!(aws_role: Role.create!(name: name).arn) if aws_role.blank?
     aws_role

--- a/test/models/app_test.rb
+++ b/test/models/app_test.rb
@@ -2,6 +2,11 @@ require 'test_helper'
 
 class AppTest < ActiveSupport::TestCase
     def setup
+      ENV['LAMBDA_POLICY_ARN'] = 'arn:aws:iam::aws:policy/service-role/FakeRole'
+      ENV['AWS_REGION'] = 'us-east-1'
+      ENV['AWS_ACCESS_KEY_ID'] = '987FAKEKEY'
+      ENV['AWS_SECRET_ACCESS_KEY'] = '123FAKEKEY'
+
       @user = User.create!(name: 'test', email: 'test@example.test', password: 'password')
       @user2 = User.create!(name: 'test2', email: 'test2@example.test', password: 'password2')
       @existing = App.create!(user: @user, owner: @user, descriptive_name: 'Existing App')


### PR DESCRIPTION
**Before**
aws keys and credentials were _required_ when creating or signing in new users

**After**
aws keys no longer _required_ and aws role creation is skipped if they are not present

**Notes**
fixes #209 