### PR TITLE
update/env_example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,11 @@ JWT_PRIVATE_KEY="
 #
 # Redis URL for notifying front end of webhook arrivals:
 # REDIS_URL='redis://localhost:6379/1'
+#
+# Mailgun configuration variables
+# MAILGUN_DOMAIN=
+# MAILGUN_PUBLIC_KEY=
+# MAILGUN_SMTP_LOGIN=
+# MAILGUN_SMTP_PASSWORD=
+# MAILGUN_SMTP_PORT=
+# MAILGUN_SMTP_SERVER=


### PR DESCRIPTION
**Before**
No Mailgun configuration variable in `.env.example`

**After**
Mailgun configuration variables now available by default