### PR TITLE
Fix/get credentials

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
+require 'env_handler'
 
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pagy::Backend
+  include EnvHandler
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
@@ -10,6 +12,7 @@ class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :render_invalid_record
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from CanCan::AccessDenied, with: :render_unauthorized
+  rescue_from EnvHandler::MissingEnvVariableError, with: :render_env_error
 
   protected
 
@@ -51,6 +54,10 @@ class ApplicationController < ActionController::API
 
   def render_not_found(err)
     render status: :not_found
+  end
+
+  def render_env_error(err)
+    render json: { error: err.message }, status: :unprocessable_entity
   end
 
   def auth_key

--- a/app/models/credentials_base.rb
+++ b/app/models/credentials_base.rb
@@ -1,4 +1,7 @@
+require 'env_handler'
+
 class CredentialsBase
+  include EnvHandler
 
   class InvalidPatch < StandardError
     def initialize
@@ -99,10 +102,12 @@ class CredentialsBase
   end
 
   def aws_client
+    aws_env_set?
     @aws_client ||= Aws::SecretsManager::Client.new
   end
 
   def self.aws_client
+    aws_env_set?
     Aws::SecretsManager::Client.new
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,7 @@
+require 'env_handler'
+
 class Role
+  include EnvHandler
 
   AFTER_CREATE_DELAY = 1.5
 
@@ -31,6 +34,7 @@ class Role
   private
 
   def self.aws_client
+    aws_env_set?
     @aws_client ||= Aws::IAM::Client.new
   end
 

--- a/lib/env_handler.rb
+++ b/lib/env_handler.rb
@@ -1,0 +1,28 @@
+module EnvHandler
+  class MissingEnvVariableError < StandardError
+  end
+
+  # set any ENV variables that need to be checked here
+  VARIABLES = ['LAMBDA_POLICY_ARN', 'AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'].freeze
+
+  def self.included(base)
+    base.extend(EnvMethods)
+    base.include(EnvMethods)
+  end
+
+  module EnvMethods
+    # creates check methods for each VARIABLE in downcased forms similar to "aws_region_set?"
+    VARIABLES.each do |variable|
+      define_method("#{variable.downcase}_set?") do
+        raise MissingEnvVariableError, "#{variable} not set" if ENV[variable].blank?
+      end
+    end
+    
+    def aws_env_set?
+      lambda_policy_arn_set?
+      aws_region_set?
+      aws_access_key_id_set?
+      aws_secret_access_key_set?
+    end
+  end
+end

--- a/spec/models/api_keys_spec.rb
+++ b/spec/models/api_keys_spec.rb
@@ -4,6 +4,7 @@ describe ApiKeys do
 
   include_context 'jwt'
   include_context 'aws_credentials'
+  include_context 'aws_env', CredentialsBase
 
   let(:app) { FactoryBot.create(:app) }
 

--- a/spec/requests/api_keys_spec.rb
+++ b/spec/requests/api_keys_spec.rb
@@ -4,6 +4,7 @@ describe 'API Key API' do
 
   include_context "jwt"
   include_context 'aws_credentials'
+  include_context 'aws_env', CredentialsBase
 
   path '/apps/{id}/api_key' do
     parameter name: :id, in: :path, type: :string

--- a/spec/requests/credential_sets_spec.rb
+++ b/spec/requests/credential_sets_spec.rb
@@ -4,6 +4,7 @@ describe 'Credential Sets API' do
 
   include_context "jwt"
   include_context 'aws_credentials'
+  include_context 'aws_env', CredentialsBase
 
   let(:user) { FactoryBot.create(:user, :logged_in) }
   let('access-token') { user.tokens[client]['token_unhashed'] }

--- a/spec/requests/credentials_spec.rb
+++ b/spec/requests/credentials_spec.rb
@@ -4,6 +4,7 @@ describe 'Credentials API' do
 
   include_context "jwt"
   include_context 'aws_credentials'
+  include_context 'aws_env', CredentialsBase
 
   path '/apps/{id}/credentials' do
     parameter name: :id, in: :path, type: :string

--- a/spec/support/aws_stubs.rb
+++ b/spec/support/aws_stubs.rb
@@ -14,7 +14,6 @@ shared_context "aws_credentials" do
   end
 end
 
-
 shared_context "aws_role" do
   include_context "stubbed_env"
 
@@ -32,5 +31,12 @@ shared_context "aws_role" do
     allow(iam_client_inst).to receive(:create_role).and_return(create_role_response)
     allow(iam_client_inst).to receive(:attach_role_policy).and_return(nil)
     stub_const('Role::AFTER_CREATE_DELAY', 0)
+  end
+end
+
+shared_context "aws_env" do |klass|
+  before do
+    allow(klass).to receive(:aws_env_set?).and_return(nil)
+    allow_any_instance_of(klass).to receive(:aws_env_set?).and_return(nil)
   end
 end


### PR DESCRIPTION
**Before**
`AWS` related `ENV` checks were tightly coupled to the `User` model, raised no specific errors

**After**
`ENV` checks are handled by meta-methods generated in the `EnvHandler` module and applied generally to various models and controllers as relevant. Specific `Errors` can be raised and caught generally at the top level by the `ApplicationController`, but in certain cases at lower levels were rescue logic can be applied