### PR TITLE
audit/tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,10 @@ class TagExists < StandardError
 end
 
 class Tag < ApplicationRecord
+  audited
+
   belongs_to :taggable, polymorphic: true
+  
   validates :name, uniqueness: { 
     scope: [:taggable_type, :taggable_id, :context] },
     strict: TagExists


### PR DESCRIPTION
**Before**
`Tags` model was not tracked by `auditable`

**After**
`Tags` are now tracked by `auditable`

**Notes**
fixes #220 