### PR TITLE
typo/app_transfer

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -70,9 +70,9 @@ class PermissionsController < ApplicationController
     end
 
     if @permissible.transfer_ownership(new_owner: @new_owner)
-      render json: { message: 'Tranfer Ownership OK'}, status: :ok
+      render json: { message: 'Transfer Ownership OK'}, status: :ok
     else
-      render json: { message: 'Tranfer Ownership Failed' }, status: :unprocessable_entity
+      render json: { message: 'Transfer Ownership Failed' }, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
**Before**
Render for `permissions_controller#transfer` had typo in message

**After**
Typo is fixed

**Notes**
none