### PR TITLE
HMAC instead of RSA for client keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ AWS_ROLE_PREFIX='_YourInitials_'
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 
+# For details on creating long lived, unscoped API keys, see:
+# https://trivial-js.org/guides/client-api-keys.html
+# CLIENT_SECRET=
+# CLIENT_KEYS=
+
+
 # Email configuration for URL generation:
 DEFAULT_URL_HOST=127.0.0.1
 DEFAULT_URL_PORT=3000

--- a/app/models/api_keys.rb
+++ b/app/models/api_keys.rb
@@ -1,4 +1,7 @@
+require 'env_handler'
+
 class ApiKeys
+  include EnvHandler
 
   class OutdatedKeyError < StandardError; end
 
@@ -117,7 +120,8 @@ class ApiKeys
   end
 
   def client_secret
-    ENV['CLIENT_SECRET'] || raise("CLIENT_SECRET not set")
+    client_secret_set?
+    ENV['CLIENT_SECRET']
   end
 
   def private_key

--- a/lib/env_handler.rb
+++ b/lib/env_handler.rb
@@ -3,7 +3,7 @@ module EnvHandler
   end
 
   # set any ENV variables that need to be checked here
-  VARIABLES = ['LAMBDA_POLICY_ARN', 'AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'].freeze
+  VARIABLES = %w[LAMBDA_POLICY_ARN AWS_REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLIENT_SECRET].freeze
 
   def self.included(base)
     base.extend(EnvMethods)


### PR DESCRIPTION
**Before**
Client keys used same `JWT_PRIVATE_TOKEN` var, which requires a multiline env var and can introduce unnecessary complexity in CI workflows.

**After**
Client keys use a dedicated `CLIENT_SECRET` var, which can be a single line string.

Note:
This will invalidate any existing client keys. There is no production usage yet, but developers will need to generate a  new pair of client keys using the new method.

Updates docs are here:
https://trivial-js.org/guides/client-api-keys.html