### PR TITLE
fix/emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ POSTGRES_PASSWORD='root'
 POSTGRES_DATABASE='trivial_development'
 POSTGRES_host='localhost'
 
+# Sets URL for front-end
+TRIVIAL_UI_URL="http://127.0.0.1:3000"
+
 # AWS settings
 AWS_ROLE_PREFIX='_YourInitials_'
 
@@ -19,7 +22,7 @@ AWS_ROLE_PREFIX='_YourInitials_'
 
 # Email configuration for URL generation:
 DEFAULT_URL_HOST=127.0.0.1
-DEFAULT_URL_PORT=3000
+DEFAULT_URL_PORT=3001
 
 LAMBDA_POLICY_ARN="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 JWT_PRIVATE_KEY="

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ JWT_PRIVATE_KEY="
 # REDIS_URL='redis://localhost:6379/1'
 #
 # Mailgun configuration variables
+MAILER_HANDLE="noreply"
 MAILGUN_DOMAIN="mg.customdomain.io"
 # MAILGUN_SMTP_LOGIN=
 # MAILGUN_SMTP_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ JWT_PRIVATE_KEY="
 # REDIS_URL='redis://localhost:6379/1'
 #
 # Mailgun configuration variables
-MAILER_HANDLE="noreply"
+MAILGUN_HANDLE="noreply"
 MAILGUN_DOMAIN="mg.customdomain.io"
 # MAILGUN_SMTP_LOGIN=
 # MAILGUN_SMTP_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ AWS_ROLE_PREFIX='_YourInitials_'
 # CLIENT_SECRET=
 # CLIENT_KEYS=
 
-
 # Email configuration for URL generation:
 DEFAULT_URL_HOST=127.0.0.1
 DEFAULT_URL_PORT=3000
@@ -26,22 +25,18 @@ LAMBDA_POLICY_ARN="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionR
 JWT_PRIVATE_KEY="
  -- see readme for instructions --
 "
-#
+
 # Optional Settings:
 #
 # Controls where Lambdas are deployed:
 # DEFAULT_LOAD_BALANCER='staging-lb'
 # BASE_URL='https://staging.trivialapps.io'
 #
-# Email configuration for URL generation:
-# DEFAULT_URL_HOST=127.0.0.1
-# DEFAULT_URL_PORT=3000
-#
 # Redis URL for notifying front end of webhook arrivals:
 # REDIS_URL='redis://localhost:6379/1'
 #
 # Mailgun configuration variables
-# MAILGUN_DOMAIN=
+MAILGUN_DOMAIN="mg.customdomain.io"
 # MAILGUN_SMTP_LOGIN=
 # MAILGUN_SMTP_PASSWORD=
 # MAILGUN_SMTP_PORT=

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_options = { from: 'noreply@mycustomdomain.com' }
+  config.action_mailer.default_options = { from: "#{ENV['MAILER_HANDLE']}@#{ENV['MAILGUN_DOMAIN']}" }
   config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL_HOST'] || "127.0.0.1", port: ENV['DEFAULT_URL_PORT'] || 3000 }
 
   ActionMailer::Base.smtp_settings = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_options = { from: "#{ENV['MAILER_HANDLE']}@#{ENV['MAILGUN_DOMAIN']}" }
+  config.action_mailer.default_options = { from: "#{ENV['MAILGUN_HANDLE'] || 'noreply'}@#{ENV['MAILGUN_DOMAIN']}" }
   config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL_HOST'] || "127.0.0.1", port: ENV['DEFAULT_URL_PORT'] || 3000 }
 
   ActionMailer::Base.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,8 +59,8 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "api_production"
 
   config.action_mailer.perform_caching = true
-  config.action_mailer.default_options = { from: 'noreply@mg.trivialapps.io' }
-  config.action_mailer.default_url_options = { host: "https://trivial-api-production.herokuapp.com" }
+  config.action_mailer.default_options = { from: "#{ENV['MAILER_HANDLE']}@#{ENV['MAILGUN_DOMAIN']}" }
+  config.action_mailer.default_url_options = { host: ENV['DEFAULT_HOST_URL'] }
 
   ActionMailer::Base.smtp_settings = {
     :port           => ENV['MAILGUN_SMTP_PORT'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "api_production"
 
   config.action_mailer.perform_caching = true
-  config.action_mailer.default_options = { from: "#{ENV['MAILER_HANDLE']}@#{ENV['MAILGUN_DOMAIN']}" }
+  config.action_mailer.default_options = { from: "#{ENV['MAILGUN_HANDLE' || 'noreply']}@#{ENV['MAILGUN_DOMAIN']}" }
   config.action_mailer.default_url_options = { host: ENV['DEFAULT_HOST_URL'] }
 
   ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
**Before**
`ActionMailer` `host` and `from` options were hard-coded to production environment settings

**After**
`ActionMailer` options are set using flexible ENV variables

**Notes**
may fix some issues related to invalid emails in relation to invitations and password recovery