### PR TITLE
actually use the serializer

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -30,12 +30,12 @@ class AppsController < ApplicationController
     @app.user = current_user
     @app.owner = current_user
     @app.save!
-    render json: @app.as_json(methods: [:aws_role])
+    render json: @app, adapter: :attributes
   end
 
   def show
     authorize! :read, app
-    render json: app.as_json(methods: [:aws_role])
+    render json: app, adapter: :attributes
   end
 
   def update


### PR DESCRIPTION
**Before**
We weren't actually using the serializer for apps#show. Trivial-UI used to pull from apps#index and filter in memory, which was causing performance issues. Now that Trivial-UI is using a more efficient route, it became apparent we weren't returning modern amenities like `app.tags`.

**After**
Use the same serializer Apps#index has been using all along.