### PR TITLE
fix/email_settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "api_production"
 
   config.action_mailer.perform_caching = true
-  config.action_mailer.default_options = { from: "#{ENV['MAILGUN_HANDLE' || 'noreply']}@#{ENV['MAILGUN_DOMAIN']}" }
+  config.action_mailer.default_options = { from: "#{ENV['MAILGUN_HANDLE'] || 'noreply'}@#{ENV['MAILGUN_DOMAIN']}" }
   config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL_HOST'] }
 
   ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
**Before**
another typo that went unnoticed in the production config file

**After**
Typo fixed

**Notes**
Silly hard to find typo based errors that give unclear exceptions are the absolute worst