### PR TITLE
update/invite_url

### DIFF
--- a/app/controllers/overrides/invitations_controller.rb
+++ b/app/controllers/overrides/invitations_controller.rb
@@ -11,9 +11,10 @@ module Overrides
 
       if invited_user = User.find_by(email: params[:email])
         invited_user.update_column(:invitation_metadata, invite_params[:invitation_metadata])
-        invited_user.invite!()
+        invited_user.invite!(nil, { trivial_ui_url: invite_params[:trivial_ui_url] })  
       else
-        invited_user = invite_resource
+        trivial_ui_url = params[:invitation].delete(:trivial_ui_url)
+        invited_user = invite_resource({ trivial_ui_url: trivial_ui_url })
       end
       
       resource_invited = invited_user.errors.empty?
@@ -58,8 +59,8 @@ module Overrides
       end
     end
 
-    def invite_resource(&block)
-      User.invite!(invite_params, current_inviter, &block)
+    def invite_resource(options = {}, &block)
+      User.invite!(invite_params, current_inviter, options, &block)
     end
 
     def accept_resource
@@ -67,7 +68,7 @@ module Overrides
     end
 
     def invite_params
-      params.require(:invitation).permit(:name, :email, :invitation_token, :provider, :skip_invitation, invitation_metadata: [:org_id, :role])
+      params.require(:invitation).permit(:name, :email, :invitation_token, :provider, :skip_invitation, :trivial_ui_url, invitation_metadata: [:org_id, :role])
     end
 
     def accept_invite_params

--- a/app/mailers/devise_invitable/mailer.rb
+++ b/app/mailers/devise_invitable/mailer.rb
@@ -1,0 +1,10 @@
+module DeviseInvitable
+  module Mailer
+    def invitation_instructions(record, token, opts = {})
+      @token = token
+      @trivial_ui_url = opts[:trivial_ui_url] || ENV['TRIVIAL_UI_URL']
+      devise_mail(record, :invitation_instructions, opts)
+    end
+  end
+end
+

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", organization: Organization.find(@resource.invitation_metadata["org_id"]).name) %></p>
 
-<p><%= link_to t("devise.mailer.invitation_instructions.accept", role: @resource.invitation_metadata["role"], organization: Organization.find(@resource.invitation_metadata["org_id"]).name), "#{ENV['TRIVIAL_UI_URL']}/acceptinvitation?invitation_token=#{@token}&email=#{@resource.email}" %></p>
+<p><%= link_to t("devise.mailer.invitation_instructions.accept", role: @resource.invitation_metadata["role"], organization: Organization.find(@resource.invitation_metadata["org_id"]).name), "#{@trivial_ui_url}/acceptinvitation?invitation_token=#{@token}&email=#{@resource.email}" %></p>
 
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -2,7 +2,7 @@
 
 <%= t("devise.mailer.invitation_instructions.someone_invited_you", organization: Organization.find(@resource.invitation_metadata["org_id"]).name) %>
 
-<%= link_to t("devise.mailer.invitation_instructions.accept", role: @resource.invitation_metadata["role"], organization: Organization.find(@resource.invitation_metadata["org_id"]).name), "#{ENV['TRIVIAL_UI_URL']}/acceptinvitation?invitation_token=#{@token}&email=#{@resource.email}" %>
+<%= link_to t("devise.mailer.invitation_instructions.accept", role: @resource.invitation_metadata["role"], organization: Organization.find(@resource.invitation_metadata["org_id"]).name), "#{@trivial_ui_url}/acceptinvitation?invitation_token=#{@token}&email=#{@resource.email}" %>
 
 <% if @resource.invitation_due_at %>
   <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>


### PR DESCRIPTION
**Before**
Invitation emails generated their invite URL from an ENV variable

**After**
The invite url base (trivial_ui_url) can now be fed to the API to dynamically generate the invite urls for emails. 

**Notes**

- url generation falls back to the old ENV variable when no url is supplied
- relies on https://github.com/solid-adventure/trivial-ui/pull/67 for full functionality
- fixes #218  