### PR TITLE
return before group if no results

### DIFF
--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -37,7 +37,7 @@ module Services
       sample = results.first
       validate_single_unit_of_measure(results) or raise "Cannot report on multiple units in the same report"
 
-      if args[:group_by]
+      if args[:group_by] && sample
       # NOTE: We accept group_by as an array to support grouping by multiple dimensions later, but for now we only support one dimension
         args[:group_by].map { |i| raise "Invalid group by, not a meta key for register" unless i.in? whitelisted_groups(results) }
         meta_groups = args[:group_by].map { |i| RegisterItem.meta_column(i, sample.register.meta) }

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -53,8 +53,8 @@ module Services
       register_ids = results.group(:register_id).size.keys
       registers = Register.select(:meta).where(id: register_ids)
       registers.each do |r|
-        r.meta.keys.each_with_index do |k, i|
-          raise "Unable to compare registers with different meta keys" unless k == registers.first.meta.keys[i]
+        r.meta.each do |key, val|
+          raise "Unable to compare registers with different meta keys" unless val == registers.first.meta[key]
         end
       end
       return registers.first.meta.values + ["register_id"]


### PR DESCRIPTION
**Before**
Rendering a report with a group that contains no results crashes:

```ruby
undefined method `meta' for nil:NilClass

      return registers.first.meta.values + ["register_id"]
                            ^^^^^
```
<img width="410" alt="Screenshot 2024-02-15 at 7 22 08 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/f6e5a3f0-debf-4d93-a02f-139c2f4b70c0">


**After**
Limited to a single register, nice clean No Results message.
<img width="425" alt="Screenshot 2024-02-15 at 7 21 46 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/32485844-f87e-4f95-aa8a-54c1a303394c">

Pulling from multiple registers with non-matching columns correctly refuses to render:
<img width="409" alt="Screenshot 2024-02-15 at 7 49 46 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/059ba458-6414-42a7-9040-f6da930307f0">


Panel Options used for testing. Note that `income_account` is a valid group_by arg for the register.
```json
{
  "options": {
    "title": "Sum, Group by Income Account",
    "full_width": false,
    "countFormat": {
      "args": {
        "places": 2
      },
      "type": "money"
    },
    "data_source": {
      "args": {
        "path": "reports/item_sum",
        "group_by": [
          "income_account"
        ]
      },
      "type": "trivial-api"
    },
    "display_total": true
  },
  "component": "HeadlineTable"
}
```