### PR TITLE
update/originated_at

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -37,9 +37,9 @@ class RegisterItemsController < ApplicationController
 
   def register_item_params
     if @register.meta.present?
-      params.permit(:unique_key, :description, :register_id, :amount, :units, @register.meta.values)
+      params.permit(:unique_key, :description, :register_id, :amount, :units, :originated_at, @register.meta.values)
     else
-      params.permit(:unique_key, :description, :register_id, :amount, :units)
+      params.permit(:unique_key, :description, :register_id, :amount, :units, :originated_at)
     end
    end
 

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -17,7 +17,7 @@ class RegisterItem < ApplicationRecord
   has_many :permitted_users, through: :permissions, source: :user
 
   # Common scopes for reports
-  scope :between, ->(start_at, end_at) { where("created_at >= ? AND created_at <= ?", start_at, end_at) }
+  scope :between, ->(start_at, end_at) { where("originated_at >= ? AND originated_at <= ?", start_at, end_at) }
 
   # Denormalized from register
   before_create :set_register_attrs

--- a/db/migrate/20240220174251_add_orginated_at_to_register_items.rb
+++ b/db/migrate/20240220174251_add_orginated_at_to_register_items.rb
@@ -1,0 +1,5 @@
+class AddOrginatedAtToRegisterItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :register_items, :originated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_02_021450) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_20_174251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -208,6 +208,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_02_021450) do
     t.string "meta9"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "originated_at"
     t.index ["owner_type", "owner_id"], name: "index_register_items_on_owner_type_and_owner_id"
     t.index ["register_id"], name: "index_register_items_on_register_id"
     t.index ["unique_key", "register_id"], name: "index_register_items_on_unique_key_and_register_id", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,34 +12,32 @@ admin = User.new
 admin.name = 'admin'
 admin.email = 'admin@email.com'
 admin.role = 'admin'
-admin.password = '12345678'
+admin.password = '@Password123'
 admin.approval = 'approved'
 admin.save!
+user = User.last
 
+income_accounts = %w(carrier_fees storage receiving shipping VAS)
+warehouses = %w(san_francisco los_angeles new_york paris london tokyo)
+channels = %w(retail wholesale online popup dropship)
+originated_at_range = ((DateTime.now - 2.years)..DateTime.now)
 
-# TODO This concept is sound and runs well in console, but should be verified before uncommeting officially
+register1 = Register.find_or_create_by(name: "Generated Register 1", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
+register2 = Register.find_or_create_by(name: "Generated Register 2", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
+register3 = Register.find_or_create_by(name: "Generated Register 3", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
+registers = [register1, register2, register3]
 
-# income_accounts = %w(carrier_fees storage receiving shipping VAS)
-# warehouses = %w(san_francisco los_angeles new_york paris london tokyo)
-# channels = %w(retail wholesale online popup dropship)
-# user = User.third
-
-# register1 = Register.find_or_create_by(name: "Generated Register 1", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
-# register2 = Register.find_or_create_by(name: "Generated Register 2", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
-# register3 = Register.find_or_create_by(name: "Generated Register 3", owner: user, units: "USD", meta: {meta0: "income_account", meta1: "warehouse", meta2: "channel" })
-# registers = [register1, register2, register3]
-
-# (1..1000000).map { |i| RegisterItem.create(
-#   register_id: registers.sample.id,
-#   owner: user,
-#   description: "Generated event #{i}",
-#   amount: rand(0.1..20.0).round(2),
-#   units: "USD",
-#   unique_key: "#{Time.now}-#{i}",
-#   income_account: income_accounts.sample,
-#   warehouse: warehouses.sample,
-#   channel: channels.sample
-# )
-# puts "Generated event #{i} of 1,000,000"
-# }
-
+2000.times do |i|
+  RegisterItem.create(
+    register_id: registers.sample.id,
+    owner: user,
+    description: "Generated event #{i}",
+    amount: rand(0.1..20.0).round(2),
+    units: "USD",
+    unique_key: "#{Time.now}-#{i}",
+    income_account: income_accounts.sample,
+    warehouse: warehouses.sample,
+    channel: channels.sample, 
+    originated_at: rand(originated_at_range)
+  )
+end


### PR DESCRIPTION
**Before**
Register items had no way of tracking when an item was originated

**After**
RegisterItems store their origination time under `originated_at` for tracking when a transaction was created outside `trivial-api`

**WIP**
- [x] Reports uses `originated_at`
- [x] `trivial-event-consumer` supplies `originated_at` (pending https://github.com/whiplashmerch/trivial-event-consumer/pull/34)
- [x] seeds script includes `originated_at` (pending https://github.com/solid-adventure/trivial-api/pull/235)