### PR TITLE
Group by period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', require: false
 
 gem 'cancancan'
 
+gem 'groupdate'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    groupdate (6.4.0)
+      activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
@@ -314,6 +316,7 @@ DEPENDENCIES
   discard (~> 1.2)
   dotenv-rails
   factory_bot_rails
+  groupdate
   jwt (~> 2.3)
   listen (~> 3.2)
   net-imap

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,7 +24,7 @@ class ReportsController < ApplicationController
   end
 
   def report_params
-    params.permit(:start_at, :end_at, :register_ids, :group_by_period, group_by: [])
+    params.permit(:start_at, :end_at, :register_ids, :group_by_period, :timezone, group_by: [])
   end
 
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,7 +13,8 @@ class ReportsController < ApplicationController
       if e.message.in? [
         "Unable to compare registers with different meta keys",
         "Cannot report on multiple units in the same report",
-        "Invalid group by, not a meta key for register"
+        "Invalid group by, not a meta key for register",
+        "Multiple groups and period groups not yet supported"
       ]
         render json: {error: e.message}, status: 500
       else
@@ -23,7 +24,7 @@ class ReportsController < ApplicationController
   end
 
   def report_params
-    params.permit(:start_at, :end_at, :register_ids, group_by: [])
+    params.permit(:start_at, :end_at, :register_ids, :group_by_period, group_by: [])
   end
 
 

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -30,23 +30,74 @@ module Services
       return unless stat.in? %w(count sum average)
 
       results = args[:user].associated_register_items
-        .between(args[:start_at], args[:end_at])
-
       results = results.where(register_id: args[:register_ids]) if args[:register_ids]
 
       sample = results.first
       validate_single_unit_of_measure(results) or raise "Cannot report on multiple units in the same report"
 
+
       if args[:group_by] && sample
       # NOTE: We accept group_by as an array to support grouping by multiple dimensions later, but for now we only support one dimension
         args[:group_by].map { |i| raise "Invalid group by, not a meta key for register" unless i.in? whitelisted_groups(results) }
         meta_groups = args[:group_by].map { |i| RegisterItem.resolved_column(i, sample.register.meta) }
+
+        results = group_by_period(results, args[:group_by_period], Date.parse(args[:start_at]), Date.parse(args[:end_at]))
         results = results.group(meta_groups).__send__(stat ,:amount)
         results = collate_register_names(results) if meta_groups.include? "register_id"
+        results = format(results)
         return {title: "Count by Register", count: results }
       end
 
-      return {title: stat.titleize, count: results.__send__(stat ,:amount) }
+      results = group_by_period(results, args[:group_by_period], Date.parse(args[:start_at]), Date.parse(args[:end_at]))
+      results = results.__send__(stat ,:amount)
+      return {title: stat.titleize, count: format(results) }
+    end
+
+    # Given an object with an array for a key like: {["Jan 2024", "b2b shipping"]=>0},
+    # OR  {"b2b shipping"=>0}
+    # returns an array of objects with string for keys: [{:period=>"Jan 2024", :group=>"b2b shipping", :value=>0}]
+    def format(results)
+      out = []
+      if ((results.is_a? String) || (results.is_a? Numeric))
+        return [{:period=>"All", :group=>"", :value=>results}]
+      end
+
+      if results&.keys&.first&.is_a? String
+        results.each do |r|
+          out.push({
+            period: "All",
+            group: r[0],
+            value: r[1]
+          })
+        end
+        return quarterize(out)
+      end
+
+      raise "Multiple groups and period groups not yet supported" if results&.keys&.first&.is_a? Array and results.keys.first.length > 2
+      results.each do |k| out.push(
+          {:period => k[0][0], :group => k[0][1], :value => k[1]}
+        )
+      end
+      return quarterize(out)
+    end
+
+    # This is a hack to get around the fact that strftime doesn't support quarters
+    # We replace "QJan 2024" with "Q1 2024" and so on
+    def quarterize(results)
+      results.each do |r|
+        r[:period] = r[:period]&.gsub(/Q(Jan|Feb|Mar)/, "Q1")&.gsub(/Q(Apr|May|Jun)/, "Q2")&.gsub(/Q(Jul|Aug|Sep)/, "Q3")&.gsub(/Q(Oct|Nov|Dec)/, "Q4")
+      end
+      return results
+    end
+
+    def group_by_period(results, period, start_at, end_at)
+      period&.downcase!
+      return results.group_by_day(:created_at, format: "%b %d %Y", range: start_at..end_at) if period == "day"
+      return results.group_by_week(:created_at, format: "%b %d %Y", range: start_at..end_at) if period == "week"
+      return results.group_by_month(:created_at, format: "%b %Y", range: start_at..end_at) if period == "month"
+      return results.group_by_quarter(:created_at, format: "Q%b %Y", range: start_at..end_at) if period == "quarter"
+      return results.group_by_year(:created_at, format: "%Y", range: start_at..end_at) if period == "year"
+      return results.between(start_at, end_at) # Pass through unchanged if no period or invalid period is specified. "total" would commonly trigger this edge case.
     end
 
     def whitelisted_groups(results)

--- a/spec/factories/register.rb
+++ b/spec/factories/register.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :register do
+    association :owner, factory: :user
+    sequence(:name) { |n| "Register #{n}" }
+    units { "USD" }
+    meta {
+      {
+        meta0: "customer_id",
+        meta1: "income_account",
+        meta2: "entity_type",
+        meta3: "entity_id"
+      }
+    }
+  end
+end

--- a/spec/factories/register_item.rb
+++ b/spec/factories/register_item.rb
@@ -1,0 +1,20 @@
+# spec/factories/register_item.rb
+
+FactoryBot.define do
+  factory :register_item do
+    association :register
+    owner { register.owner }
+    sequence(:description) { |n| "RegisterItem #{n}" }
+    amount { 2.50 }
+    units { register.units }
+    originated_at { Time.now }
+    sequence(:unique_key) { |n| "Order.#{n}.#{originated_at}" }
+
+    # meta column labels are sourced from register.meta
+    meta0 { "29" } # default customer_id
+    sequence(:meta1) { |n| "Account #{n}" } # default income_account
+    meta2 { "Order" } # default entity_type
+    sequence(:meta3) { |n| "#{n}" } # default entity_id
+    # meta[4-9] default to nil and have no default label
+  end
+end

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -1,0 +1,91 @@
+# spec/lib/report_spec.rb
+
+require 'rails_helper'
+require 'services/report'
+
+RSpec.describe Services::Report do
+  let(:report) { Services::Report.new }
+  let(:register) { FactoryBot.create :register }
+  let(:owner) { register.owner }
+  # args = :start_at, :end_at, :register_ids, :group_by_period, :timezone, group_by: []
+
+  before do
+  end
+
+  describe "simple_stat_lookup" do
+    let(:start_at) { Time.new(2023, 1, 1, 0, 0, 0, "-04:00") } # Jan 1, 2023 12:00:00AM EDT
+    let(:end_at) { start_at + 1.year - 1.second } # Dec 31, 2023 11:59:59PM EDT
+    let(:register_ids) { register.id }
+    let(:args) { 
+      {
+        start_at: start_at.to_s,
+        end_at: end_at.to_s,
+        register_ids:,
+        user: owner
+      }
+    }
+    let(:originated_at) { start_at + 1.month } # Feb 1, 2023 12:00:00AM EDT
+
+    before do
+      FactoryBot.create(:register_item, originated_at:)
+      FactoryBot.create(:register_item, register:, originated_at:)
+      FactoryBot.create(
+        :register_item,
+        register:,
+        originated_at: start_at + 3.months + 1.hour # April 1, 2023 1:00:00AM EDT
+      )
+      FactoryBot.create(:register_item, register: FactoryBot.create(:register, owner:), originated_at:)
+    end
+
+    it "only includes specified registers" do
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].first[:value]).to eq(2)
+    end
+
+    it "only includes specified dates" do
+      args[:end_at] = (start_at + 2.months - 1.second).to_s # Feb 28, 2023 11:59:59PM EDT
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].first[:value]).to eq(1)
+    end
+
+    it "correctly groups results given a :group_by" do
+      args[:group_by] = ["register_id"]
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].count).to eq(1)
+      expect(results[:count].first[:value]).to eq(2)
+
+      args[:group_by] = ["income_account"]
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].count).to eq(2)
+      results[:count].each do |group|
+        expect(group[:value]).to eq(1)
+      end
+    end
+
+    it "correctly groups by time period" do
+      args[:group_by_period] = 'month'
+      args[:timezone] = "Etc/GMT+4" # EDT
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].count).to eq(12)
+      expect(results[:count][0][:value]).to eq(0) # January, 2023 EDT
+      expect(results[:count][1][:value]).to eq(1) # February, 2023 EDT
+      expect(results[:count][2][:value]).to eq(0) # March, 2023 EDT
+      expect(results[:count][3][:value]).to eq(1) # April, 2023 EDT
+      expect(results[:count][4][:value]).to eq(0) # May, 2023 EDT
+    end
+
+    it "correctly accounts for timezones" do
+      args[:start_at] = Time.new(2023, 1, 1, 0, 0, 0, "-05:00").to_s # Jan 1, 2023 12:00:00AM EST
+      args[:end_at] = Time.new(2023, 12, 31, 23, 59, 59, "-05:00").to_s # Dec 31, 2023 11:59:59PM EST
+      args[:group_by_period] = 'month'
+      args[:timezone] = "Etc/GMT+5" # EST
+      results = report.send(:simple_stat_lookup, "count", args)
+      expect(results[:count].count).to eq(12)
+      expect(results[:count][0][:value]).to eq(1) # January, 2023 EST
+      expect(results[:count][1][:value]).to eq(0) # February, 2023 EST
+      expect(results[:count][2][:value]).to eq(0) # March, 2023 EST
+      expect(results[:count][3][:value]).to eq(1) # April, 2023 EST
+      expect(results[:count][4][:value]).to eq(0) # May, 2023 EST
+    end
+  end
+end


### PR DESCRIPTION
Note: requires https://github.com/solid-adventure/trivial-ui/pull/72

**Before**
All results for a dashboard are returned in a single total.

**After**
Dashboard results are grouped by human increments: **Day, Week, Month, Quarter, Year, Total Only.**

In addition to passing the `group_period` from the UI, we also need to pass the timezone, even though the dates are converted to UTC by the UI and the database is in UTC.

Without this, you end up with an extra day in your results, which is very obvious on reports like "Last Month, group by Month", in which you will have 2 months in your results. The "extra" period will show no results because the `WHERE` clause is scoped to the correct UTC time, but the `SELECT` time used for the group is not.

With the timezone param, we're able to let the DB do the GROUP BY work it's best at, and get clean results in the desired TZ:

```SQL
 SELECT
	SUM("register_items"."amount") AS "sum_amount",
	DATE_TRUNC('day', "register_items"."created_at"::timestamptz AT TIME ZONE 'America/Detroit')::date AS "date_trunc_day_register_items_created_at_timestamptz_at_time_zo",
	"register_items"."meta1" AS "register_items_meta1"
FROM
	"register_items"
WHERE ("register_items"."owner_type" = $1
	AND "register_items"."owner_id" = $2
	OR "register_items"."owner_type" = $3
	AND "register_items"."owner_id" IN($4, $5)
	OR 1 = 0)
AND "register_items"."register_id" = $6
AND("register_items"."created_at" >= '2024-02-13 05:00:00'
	AND "register_items"."created_at" <= '2024-02-14 04:59:59.999000')
GROUP BY
	DATE_TRUNC('day', "register_items"."created_at"::timestamptz AT TIME ZONE 'America/Detroit')::date,
	"register_items"."meta1"
--  [["owner_type", "User"], ["owner_id", 3], ["owner_type", "Organization"], ["owner_id", 11], ["owner_id", 19], ["register_id", 57]]

```
<img width="1081" alt="Screenshot 2024-02-24 at 2 50 25 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/e0eaa49c-9248-471f-aee2-52825e1d8819">
<img width="1106" alt="Screenshot 2024-02-24 at 2 33 06 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/0e49a453-3c1b-45a5-8a96-5686be8ff7a1">
<img width="1093" alt="Screenshot 2024-02-24 at 2 33 16 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/698bd274-72cd-4d68-8105-4a9cc4d31f96">
<img width="1082" alt="Screenshot 2024-02-24 at 2 33 23 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/d2cd41b2-bd88-4a08-bbf8-4935d0289f9f">
<img width="1093" alt="Screenshot 2024-02-24 at 2 33 30 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/0062d6b6-beb0-4fe7-b07b-521b0ea1c5c5">
<img width="687" alt="Screenshot 2024-02-24 at 2 33 01 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/32cf57a8-1a94-4793-8b9e-6c179059a3ff">
<img width="1086" alt="Screenshot 2024-02-24 at 2 33 38 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/651f4055-2fc2-490c-9e48-4ef6a1877d1f">
<img width="1079" alt="Screenshot 2024-02-24 at 2 33 48 PM" src="https://github.com/solid-adventure/trivial-api/assets/80924/bc6f4a8f-5cdd-491e-9b96-7ec6ea3d4854">
