### PR TITLE
cors uses ui env var

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,7 +8,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['TRIVIAL_UI_URL']
+    origins ENV['TRIVIAL_UI_URL'] || ''
 
     resource '*',
       headers: :any,
@@ -21,4 +21,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
         'uid'
       ]
   end
+  puts "Accepting requests from Trivial UI from: #{ENV['TRIVIAL_UI_URL'] || 'No URL provided, set TRIVIAL_UI_URL to enable CORS.'}"
+
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,10 +8,17 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:3000', '127.0.0.1:3000'
+    origins ENV['TRIVIAL_UI_URL']
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+
+      expose: [
+        'access-token',
+        'client',
+        'expiry',
+        'uid'
+      ]
   end
 end


### PR DESCRIPTION
**Before**
Unhelpful cors policy, API was not leveraged directly from UI so it did not matter.

**After**
Cors enabled specifically to trivial ui.

Note: You must have `TRIVIAL_UI_URL` set.