### PR TITLE
feature/entry-search

### DIFF
--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -1,7 +1,10 @@
 require 'uri'
 require 'net/http'
+require 'search'
 
 class ActivityEntry < ApplicationRecord
+  include Search
+
   validates :source, presence: true, if: :is_request?
 
   belongs_to :app
@@ -96,6 +99,14 @@ class ActivityEntry < ApplicationRecord
   def normalize_json
     self.payload = JSON.parse(payload) rescue payload if payload.instance_of?(String)
     self.diagnostics = JSON.parse(diagnostics) rescue diagnostics if diagnostics.instance_of?(String)
+  end
+
+  def self.search(entries, search)
+    search.entries.each do |column, arguments|
+      query = create_query(column, arguments[:operator], arguments[:predicate])
+      entries = entries.where(query)
+    end
+    return entries
   end
 
   def self.send_new(app, payload)

--- a/db/migrate/20240401150728_add_indexes_to_activity_entry.rb
+++ b/db/migrate/20240401150728_add_indexes_to_activity_entry.rb
@@ -1,0 +1,5 @@
+class AddIndexesToActivityEntry < ActiveRecord::Migration[7.0]
+  def change
+    add_index :activity_entries, :payload, using: 'gin'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_20_174251) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_01_150728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_174251) do
     t.bigint "owner_id"
     t.index ["app_id"], name: "index_activity_entries_on_app_id"
     t.index ["owner_type", "owner_id"], name: "index_activity_entries_on_owner"
+    t.index ["payload"], name: "index_activity_entries_on_payload", using: :gin
     t.index ["update_id"], name: "index_activity_entries_on_update_id"
   end
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1,0 +1,49 @@
+module Search
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  JSONB_OPERATORS = %w[? ?& ?| @> @? @@]
+  COMPERATORS = %w[< > <= >= = <>]
+  PREDICATES = ['IS NULL','IS NOT NULL','IS TRUE','IS NOT TRUE','IS FALSE','IS NOT FALSE']
+
+  class InvalidColumnError < StandardError
+    def initialize(msg = 'Invalid or Empty column')
+      super(msg)
+    end
+  end
+
+  class InvalidOperatorError < StandardError
+    def initialize(msg = 'Invalid or Empty operator')
+      super(msg)
+    end
+  end
+  
+  class InvalidPredicateError < StandardError
+    def initialize(msg = 'Invalid or Empty predicate')
+      super(msg)
+    end
+  end
+
+  module ClassMethods
+    def create_query(column, operator, predicate)
+      raise InvalidPredicateError unless predicate
+      raise InvalidColumnError unless column_names.include?(column)
+      query = "#{column} "
+      
+      data_type = columns_hash[column].type
+      if data_type == :jsonb
+        raise InvalidOperatorError unless JSONB_OPERATORS.include?(operator)
+        query << "#{operator}"
+      else # string, integer, and most other data types will use standard comperators
+        if operator.empty? # no operator is necessary for SQL defined predicates
+          raise InvalidPredicateError unless PREDICATES.include?(predicate)
+        else
+          raise InvalidOperatorError unless COMPERATORS.include?(operator)
+          query << "#{operator}"
+        end
+      end
+      return sanitize_sql_array(["#{query} ?", predicate])
+    end
+  end
+end


### PR DESCRIPTION
**Before**
No ability to filter or search `ActivityEntry` records outside of `app_id`

**After**
Minimal search endpoint that can accept JSON-like query strings and filter for top-level keys within the `payload` column