### PR TITLE
initial support for kafka resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,18 @@ MAILGUN_DOMAIN="mg.customdomain.io"
 # MAILGUN_SMTP_PASSWORD=
 # MAILGUN_SMTP_PORT=
 # MAILGUN_SMTP_SERVER=
+
+
+# The service ActivityEntry Send and Re-Send will use
+# DEFAULT_APP_RUNNER_SERVICE=webhook # Default is 'webhook', 'Kafka' is also supported
+
+# Required if DEFAULT_APP_RUNNER_SERVICE is set to kafka
+# KAFKA_USERNAME=
+# KAFKA_PASSWORD=
+# KAFKA_BOOTSTRAP_SERVERS=
+# KAFKA_TOPIC=
+# KAFKA_NAMESPACE= # Optional, will be prependended to topic
+
+
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem 'cancancan'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# Kafka producer
+gem 'waterdrop'
+
 gem 'audited'
 
 gem 'devise_token_auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,12 @@ GEM
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
     jwt (2.7.1)
+    karafka-core (2.3.0)
+      karafka-rdkafka (>= 0.14.8, < 0.15.0)
+    karafka-rdkafka (0.14.10)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -276,6 +282,9 @@ GEM
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    waterdrop (2.6.14)
+      karafka-core (>= 2.2.3, < 3.0.0)
+      zeitwerk (~> 2.3)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -323,6 +332,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  waterdrop
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/lib/services/kafka.rb
+++ b/lib/services/kafka.rb
@@ -1,0 +1,40 @@
+module Services
+  class Kafka
+
+    def initialize
+      @producer = WaterDrop::Producer.new do |config|
+        config.deliver = true
+        config.kafka = {
+          'bootstrap.servers': ENV['KAFKA_BOOTSTRAP_SERVERS'],
+          'sasl.username': ENV['KAFKA_USERNAME'],
+          'sasl.password': ENV['KAFKA_PASSWORD'],
+          'security.protocol': 'SASL_SSL',
+          'sasl.mechanisms': 'PLAIN',
+          'request.required.acks': 1
+        }
+      end
+    end
+
+    def producer
+      @producer
+    end
+
+    def produce_sync(topic:, payload:, key:)
+      validate_payload(payload)
+      producer.produce_sync(topic: topic, payload: payload, key: key)
+    end
+
+    def validate_payload(payload=nil)
+      payload = JSON.parse(payload)
+      raise "Invalid payload, JSON invalid" unless payload.is_a?(Hash)
+      raise "Invalid payload, key not defined" unless payload["key"]
+    end
+
+    def self.topic(topic=nil)
+      parts = [ENV['KAFKA_NAMESPACE'], ENV['KAFKA_TOPIC'], topic].compact.reject(&:empty?)
+      raise "Invalid topic" if parts.empty?
+      parts.join('-')
+    end
+
+  end
+end

--- a/test/lib/services/kafka.rb
+++ b/test/lib/services/kafka.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class KafkaTest < ActiveSupport::TestCase
+
+  def setup
+    @kafka = Services::Kafka.new
+  end
+
+  test 'initializes' do
+    assert_instance_of WaterDrop::Producer, @kafka.producer
+  end
+
+  test 'throws when topic is not set' do
+    mock_enviroment(partial_env_hash:{"KAFKA_TOPIC"=>"", "KAFKA_NAMESPACE" => ""}) do
+      assert_raises RuntimeError do
+        Services::Kafka.topic
+      end
+    end
+  end
+
+  test 'derives topic from env var' do
+    mock_enviroment(partial_env_hash:{"KAFKA_TOPIC"=>"events"}) do
+      assert_equal "events", Services::Kafka.topic
+    end
+  end
+
+  test 'appends runtime topic' do
+    mock_enviroment(partial_env_hash:{"KAFKA_TOPIC" => "events", "KAFKA_NAMESPACE" => "SUP"}) do
+      assert_equal "SUP-events", Services::Kafka.topic
+      assert_equal "SUP-events-suffix", Services::Kafka.topic('suffix')
+    end
+
+    mock_enviroment(partial_env_hash:{"KAFKA_TOPIC" => "", "KAFKA_NAMESPACE" => ""}) do
+      assert_equal "suffix", Services::Kafka.topic('suffix')
+    end
+  end
+
+
+  test 'throws when payload is nil' do
+    assert_raises TypeError do
+      @kafka.produce_sync(topic: "events", payload: nil, key: "key")
+    end
+  end
+
+  test 'does not throw when payload is valid' do
+    assert_nothing_raised do
+      @kafka.validate_payload({key: "value"}.to_json)
+    end
+  end
+
+
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,5 +14,21 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    def mock_enviroment(env: "test", partial_env_hash: {})
+      old_env_mode = Rails.env
+      old_env = ENV.to_hash
+
+      Rails.env = env
+      ENV.update(partial_env_hash)
+
+      begin
+        yield
+      ensure
+         Rails.env = old_env_mode
+         ENV.replace(old_env)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
**Before**
`@activity_entry.resend` and `@activity_entry.send_new` will always attempt to create an HTTP POST request. 

**After**
- Support for a new env var, `DEFAULT_APP_RUNNER_SERVICE`, which accepts `kafka` or `webhook`
- If no value is set, `webhook` is assumed to maintain backwards-compatibility
- If set to `kafka`, will attempt to push the message to the Kafka queue configured with the new `KAFKA_` env vars 

TODO
- [x] Implement `send_new`