### PR TITLE
update/search-formatting

### DIFF
--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -133,8 +133,8 @@ class ActivityEntry < ApplicationRecord
   end
 
   def self.search(entries, search)
-    search.entries.each do |column, arguments|
-      query = create_query(column, arguments["operator"], arguments["predicate"])
+    search.each do |hash|
+      query = create_query(hash["c"], hash["o"], hash["p"])
       entries = entries.where(query)
     end
     return entries

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -4,7 +4,7 @@ module Search
   end
 
   JSONB_OPERATORS = %w[? ?& ?| @> @? @@]
-  COMPERATORS = %w[< > <= >= = <>]
+  COMPERATORS = %w[< > <= >= = <> !=]
   PREDICATES = ['IS NULL','IS NOT NULL','IS TRUE','IS NOT TRUE','IS FALSE','IS NOT FALSE']
 
   class InvalidColumnError < StandardError


### PR DESCRIPTION
**Before**
search query was formatted as:
`{ column: { operator: "value", predicate: "value" } }`

**After**
Formatted as an array like follows:
`[{c:"column_name",o:"=",p:"value"},{c:"column_name",o:"@@",p:"jsonb_path_predicate"}]`

`!=` is now a valid operator