### PR TITLE
feature/jsonb-keys-endpoint

### DIFF
--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -140,6 +140,23 @@ class ActivityEntry < ApplicationRecord
     return entries
   end
 
+  def self.get_keys(app_id, col, path)
+    raise 'Invalid Column' unless valid_jsonb_col?(col)
+    relation = self.where(app_id: app_id)
+
+    if path
+      query = sanitize_sql_array(["jsonb_object_keys(#{col}#>?)", path])
+    else
+      query = "jsonb_object_keys(#{col})"
+    end
+
+    return relation.distinct.pluck(Arel.sql(query))
+  end
+
+  def self.valid_jsonb_col?(col)
+    return column_names.include?(col) && columns_hash[col].type == :jsonb
+  end
+
   def self.send_new_webhook(app, payload)
     entry = ActivityEntry.new app: app
     res = post entry.app_uri, payload,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
   resources :activity_entries, only: [:index, :create, :show, :create_from_request, :update] do
     collection do
       get 'stats'
+      get 'keys'
     end
 
     member do


### PR DESCRIPTION
**Before**
No way to fetch keys data from jsonb columns on ActivityEntry

**After**
API has endpoint `/activity_entries/keys` that accepts query strings to fetch all distinct top-level keys from some set of jsonb data