### PR TITLE
update/search-keys-api

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -14,7 +14,7 @@ class ActivityEntriesController < ApplicationController
         if entries.any?
           render json: entries.map(&:activity_attributes_for_index).to_json
         else
-          render json: entries.to_json, status: :no_content
+          render json: entries.to_json, status: :ok
         end
       rescue StandardError => exception
         render_errors(exception, status: :unprocessable_entity)
@@ -89,11 +89,7 @@ class ActivityEntriesController < ApplicationController
       raise 'col query string required for keys query' unless params[:col]
      
       keys = ActivityEntry.get_keys(current_app_id, params[:col], params[:path])
-      if keys.empty?
-        render json: keys.to_json, status: :no_content
-      else 
-        render json: keys.to_json, status: :ok
-      end
+      render json: keys.to_json, status: :ok
     rescue StandardError => exception
       render_errors(exception, status: :unprocessable_entity)
     end

--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -11,7 +11,11 @@ class ActivityEntriesController < ApplicationController
       search = JSON.parse(params[:search])
       begin
         entries = ActivityEntry.search(app_activity, search)
-        render json: entries.map(&:activity_attributes_for_index).to_json
+        if entries.any?
+          render json: entries.map(&:activity_attributes_for_index).to_json
+        else
+          render json: entries.to_json, status: :no_content
+        end
       rescue StandardError => exception
         render_errors(exception, status: :unprocessable_entity)
       end
@@ -85,10 +89,10 @@ class ActivityEntriesController < ApplicationController
       raise 'col query string required for keys query' unless params[:col]
      
       keys = ActivityEntry.get_keys(current_app_id, params[:col], params[:path])
-      if keys.any?
-        render json: keys.to_json, status: :ok
+      if keys.empty?
+        render json: keys.to_json, status: :no_content
       else 
-        render json: keys.to_json, status: :not_found
+        render json: keys.to_json, status: :ok
       end
     rescue StandardError => exception
       render_errors(exception, status: :unprocessable_entity)

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -146,13 +146,13 @@ class ActivityEntry < ApplicationRecord
 
     if path
       type_query = sanitize_sql_array(["jsonb_typeof(#{col} #> ?)", path])
-      type = relation.pluck(Arel.sql(type_query)).first
+      type = relation.distinct.pluck(Arel.sql(type_query)).compact.first
 
       if type == 'object'
         query = "jsonb_object_keys(#{col} #> ?)"
         query = sanitize_sql_array([query, path])
       else 
-        return type
+        return []
       end
     else
       query = "jsonb_object_keys(#{col})"

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -145,7 +145,15 @@ class ActivityEntry < ApplicationRecord
     relation = self.where(app_id: app_id)
 
     if path
-      query = sanitize_sql_array(["jsonb_object_keys(#{col}#>?)", path])
+      type_query = sanitize_sql_array(["jsonb_typeof(#{col} #> ?)", path])
+      type = relation.pluck(Arel.sql(type_query)).first
+
+      if type == 'object'
+        query = "jsonb_object_keys(#{col} #> ?)"
+        query = sanitize_sql_array([query, path])
+      else 
+        return type
+      end
     else
       query = "jsonb_object_keys(#{col})"
     end


### PR DESCRIPTION
**Before**
- Search failed to render empty responses
- Keys API errored on paths to non hash-object fields
- Empty responses for both returned 422 (error-like response code)

**After**
- Search renders empty array for empty responses
- API keys returns the data type as a string if the path does not lead to a hash-object
- Both return `204 No Content` (a success code denoting no body)