### PR TITLE
enhance/register-items-meta

### DIFF
--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -5,6 +5,9 @@ class RegisterItem < ApplicationRecord
 
   belongs_to :register
 
+  @@initialized_registers = {}
+  @@initialization_lock = Mutex.new
+
   # Item identiy basics
   validates :description, presence: true
   validates :amount, presence: true
@@ -21,7 +24,7 @@ class RegisterItem < ApplicationRecord
 
   # Denormalized from register
   before_create :set_register_attrs
-  after_initialize :register_meta_attributes
+  after_initialize :initialize_by_register
 
   def set_register_attrs
     self.units ||= register.units
@@ -31,13 +34,39 @@ class RegisterItem < ApplicationRecord
     super(args)
   rescue ActiveRecord::UnknownAttributeError
     register = Register.find(args[:register_id])
-    register_meta_attributes(register.meta)
+    @@initialization_lock.synchronize do
+      register_meta_attributes(register.meta)
+      @@initialized_registers[register.id] = true
+    end
     super(args)
   end
 
-  def register_meta_attributes
+  def resolved_column(label, column_labels)
+    RegisterItem.resolved_column(label, column_labels)
+  end
+
+  def self.resolved_column(label, column_labels)
+    return label if label.in? column_names
+    out = column_labels.find{ |k,v|  v==label }.first
+    raise "No meta column found for #{label}" unless out
+    return out
+  end
+
+  def self.sanitize(str)
+    str.gsub(' ', '_').underscore.gsub(/[^a-zA-Z0-9_]/, '')
+  end
+
+  private
+
+  def initialize_by_register
     raise "You must provide a register_id to create register items" unless register_id
-    RegisterItem.register_meta_attributes(register.meta)
+
+    @@initialization_lock.synchronize do
+      unless @@initialized_registers[register_id]
+        RegisterItem.register_meta_attributes(register.meta)
+        @@initialized_registers[register_id] = true
+      end
+    end
   end
 
   def self.register_meta_attributes(column_labels)
@@ -46,28 +75,13 @@ class RegisterItem < ApplicationRecord
 
       label = sanitize(column_labels[attr_name])
       define_method label do
-        self[meta_column(label, column_labels)]
+        self[resolved_column(label, column_labels)]
       end
 
       define_method "#{label}=" do |val|
-        self[meta_column(label, column_labels)] = val
+        self[resolved_column(label, column_labels)] = val
       end
     end
-  end
-
-  def meta_column(label, column_labels)
-    RegisterItem.meta_column(label, column_labels)
-  end
-
-  def self.meta_column(label, column_labels)
-    return label if label.in? %w( register_id owner_id owner_type created_at updated_at)
-    out = column_labels.find{ |k,v|  v==label }.first
-    raise "No meta column found for #{label}" unless out
-    return out
-  end
-
-  def self.sanitize(str)
-    str.gsub(' ', '_').underscore.gsub(/[^a-zA-Z0-9_]/, '')
   end
 
 end

--- a/app/serializers/register_item_serializer.rb
+++ b/app/serializers/register_item_serializer.rb
@@ -1,13 +1,20 @@
 class RegisterItemSerializer < ActiveModel::Serializer
   attributes :id, :register_id, :owner_type, :owner_id, :unique_key, :description, :amount, :units, :created_at
 
+  @@register_metas = {}
+
   def attributes(*args)
     data = super
-    return data unless object.register.meta.present?
-    register_meta = object.register.meta.symbolize_keys
-    register_meta.values.each do |label|
+    return data unless object.register_id
+    
+    unless @@register_metas[object.register_id]
+      @@register_metas[object.register_id] = object.register.meta.symbolize_keys
+    end
+    
+    @@register_metas[object.register_id].values.each do |label|
       data[label] = object.send(label)
     end
+
     data
   end
 end

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -40,7 +40,7 @@ module Services
       if args[:group_by] && sample
       # NOTE: We accept group_by as an array to support grouping by multiple dimensions later, but for now we only support one dimension
         args[:group_by].map { |i| raise "Invalid group by, not a meta key for register" unless i.in? whitelisted_groups(results) }
-        meta_groups = args[:group_by].map { |i| RegisterItem.meta_column(i, sample.register.meta) }
+        meta_groups = args[:group_by].map { |i| RegisterItem.resolved_column(i, sample.register.meta) }
         results = results.group(meta_groups).__send__(stat ,:amount)
         results = collate_register_names(results) if meta_groups.include? "register_id"
         return {title: "Count by Register", count: results }


### PR DESCRIPTION
**Before**
Lots of SQL calls and method initialization for each instantiated or serialized `RegisterItem` object

**After**
- Register retrieval only when necessary
- Initializes aliasing methods only once per application lifetime on first encounter
- renamed `meta_column` to `resolved_column` for clarity of purpose