### PR TITLE
feature/register-pagination

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -1,18 +1,31 @@
 class RegisterItemsController < ApplicationController
   before_action :set_register
   before_action :set_register_item, only: %i[ show update ]
+  before_action :set_pagination_params, only %i[index]
+  before_action :set_ordering_params, only %i[index]
 
   # GET /register_items
   def index
     begin
       @register_items = current_user.associated_register_items
+      @register_items = @register_items.where(register_id: @register.id) if @register
+      
       search = params[:search] ? JSON.parse(params[:search]) : []
       if search.any?
         raise 'register_id required for search' unless @register
-        @register_items = @register_items.where(register_id: @register.id)
         @register_items = RegisterItem.search(@register_items, @register.meta, search)
       end
-      render json: @register_items, adapter: :attributes
+
+      if @register
+        order = RegisterItem.resolved_ordering(params[:order_by], params[:ordering_direction], @register.meta)
+      else
+        order = RegisterItem.create_ordering(params[:order_by], params[:ordering_direction])
+      end
+      @register_items = @register_items.order(order)
+      
+      response_data = paginate_register_items
+
+      render json: response_data
     rescue StandardError => exception
       render_errors(exception, status: :unprocessable_entity)
     end
@@ -55,6 +68,38 @@ class RegisterItemsController < ApplicationController
   end
 
   private
+  MAX_PER_PAGE = 100
+
+  def paginate_register_items
+    offset = (params[:page] - 1) * @per_page
+    @register_items = @register_items.limit(@per_page).offset(offset)
+
+    total_pages = (@register_items.count.to_f / @per_page).ceil
+    return {
+      current_page: params[:page],
+      total_pages: total_pages,
+      register_items: ActiveModel::Serializer::CollectionSerializer.new(@register_items, adapter: :attributes)
+    }
+  end
+
+  def set_pagination_params
+    params[:per_page] ||= MAX_PER_PAGE
+    params[:page] = params[:page] ? params[:page] : 1
+    
+    if !params[:per_page].is_a?(Integer) || params[:per_page] < 1 
+      render_errors('per_page param invalid', status: :unprocessable_entity)
+    else if !params[:page].is_a?(Integer) || params[:page] < 1
+      render_errors('page param invalid', status: :unprocessable_entity)
+    else
+      @per_page = params[:per_page]
+    end
+  end
+
+  def set_ordering_params
+    params[:order_by] ||= "originated_at"
+    params[:ordering_direction] ||= "DESC"
+  end
+
   def set_register
     @register = Register.find_by_id(params[:register_id])
   end

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -73,6 +73,11 @@ class RegisterItem < ApplicationRecord
     return items
   end
 
+  def self.resolved_ordering(order_by, ordering_direction, column_labels)
+    column = resolved_column(order_by, column_labels)
+    return create_ordering(column, ordering_direction)
+  end
+
   private
 
   def initialize_by_register

--- a/app/serializers/register_item_serializer.rb
+++ b/app/serializers/register_item_serializer.rb
@@ -1,5 +1,5 @@
 class RegisterItemSerializer < ActiveModel::Serializer
-  attributes :id, :register_id, :owner_type, :owner_id, :unique_key, :description, :amount, :units, :created_at
+  attributes :id, :register_id, :owner_type, :owner_id, :unique_key, :description, :amount, :units, :originated_at, :created_at
 
   @@register_metas = {}
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -6,6 +6,7 @@ module Search
   JSONB_OPERATORS = %w[? ?& ?| @> @? @@]
   COMPERATORS = %w[< > <= >= = <> !=]
   PREDICATES = ['IS NULL','IS NOT NULL','IS TRUE','IS NOT TRUE','IS FALSE','IS NOT FALSE']
+  ORDERINGS = ['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS FIRST', 'ASC NULLS LAST', 'DESC NULLS LAST']
 
   class InvalidColumnError < StandardError
     def initialize(msg = 'Invalid or Empty column')
@@ -25,7 +26,18 @@ module Search
     end
   end
 
+  class InvalidOrderingError < StandardError
+    def initialize(msg = 'Invalid or Empty ordering')
+      super(msg)
+    end
+
   module ClassMethods
+    def create_ordering(column, order)
+      raise InvalidColumnError unless column_names.include?(column)
+      raise InvalidOrderingError unless ORDERINGS.include?(order)
+      return sanitize_sql_array([":column :ordering", column: column, order: order])
+    end
+
     def create_query(column, operator, predicate)
       raise InvalidPredicateError unless predicate
       raise InvalidColumnError unless column_names.include?(column)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -30,12 +30,13 @@ module Search
     def initialize(msg = 'Invalid or Empty ordering')
       super(msg)
     end
+  end
 
   module ClassMethods
-    def create_ordering(column, order)
+    def create_ordering(column, ordering)
       raise InvalidColumnError unless column_names.include?(column)
-      raise InvalidOrderingError unless ORDERINGS.include?(order)
-      return sanitize_sql_array([":column :ordering", column: column, order: order])
+      raise InvalidOrderingError unless ORDERINGS.include?(ordering)
+      return "#{column} #{ordering}"
     end
 
     def create_query(column, operator, predicate)


### PR DESCRIPTION
**Before**
`RegisterItem` index results had no limit or pagination for their return and could not be specifically ordered

**After**
- `RegisterItem` index will always be paginated and return the current page and total pages as a part of the response
- `RegisterItem` index can be ordered or sorted by a specific column. NOTE: multi-column ordering is not supported
- `RegisterItem` index can be narrowed by `Register` without search params
- `Search` has new method for creating sanitized ordering queries