### PR TITLE
feature/audit-register-items

### DIFF
--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -6,6 +6,8 @@ class RegisterItem < ApplicationRecord
   include Permissible
   include Search
 
+  audited
+
   # includes only non-meta searchable columns
   # meta columns are handled by self.search
   SEARCHABLE_COLUMNS = %w[amount units unique_key].freeze


### PR DESCRIPTION
**Before**
`RegisterItem` model was not tracked by auditable gem

**After**
`RegisterItem` model is now auditable