### PR TITLE
fix/resolve_meta_columns

### DIFF
--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -56,9 +56,9 @@ class RegisterItem < ApplicationRecord
 
   def self.resolved_column(label, column_labels)
     return label if label.in? column_names
-    out = column_labels.find{ |k,v|  v==label }.first
-    raise "No meta column found for #{label}" unless out
-    return out
+    meta_column = column_labels.invert[label]
+    raise "No meta column found for #{label}" unless meta_column
+    return meta_column
   end
 
   def self.sanitize(str)


### PR DESCRIPTION
**Before**
attempting to resolve a label that did not exist would fail on `undefined method 'first' for nil:NilClass`

**After**
- labels that do not match an alias for a meta-column resolve to `nil` and raise the correct exception
- output is more clearly named