### PR TITLE
feature/display-app-saves

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -14,6 +14,25 @@ class Manifest < ApplicationRecord
 
     has_one_attached :bundle
 
+    after_save :create_activity_entry
+
+    def create_activity_entry
+        current_audit = audits.last
+        entry = ActivityEntry.new
+        entry.owner = owner
+        entry.app = app
+        entry.activity_type = 'build'
+        entry.status = '200'
+        entry.diagnostics = {
+            build_info: {
+                audit_id: current_audit.id,
+                action: current_audit.action,
+                user: current_audit.user_id
+            }
+        }
+        entry.save!
+    end
+
     def copy_to_app!(new_app)
         new_manifest = self.dup
         new_manifest.app_id = new_app.name


### PR DESCRIPTION
**Before**
Building apps did not create a visible way of tracking creation and updates

**After**
`Manifest` saves will trigger creation of an `ActivityEntry` which points to an `Audit` detailing changes to the `Manifest`