### PR TITLE
enhance/add-search-columns

### DIFF
--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -10,7 +10,7 @@ class RegisterItem < ApplicationRecord
 
   # includes only non-meta searchable columns
   # meta columns are handled by self.search
-  SEARCHABLE_COLUMNS = %w[amount units unique_key].freeze
+  SEARCHABLE_COLUMNS = %w[originated_at description amount units unique_key].freeze
 
   belongs_to :register
 


### PR DESCRIPTION
**Before**
`description` and `originated_at` were not searchable columns for `register_items`

**After**
`description` and `originated_at` are now searchable