### PR TITLE
enhance/entries-and-register-items-relation

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -97,7 +97,7 @@ class ActivityEntriesController < ApplicationController
 
   private
   def activity_for_index
-    attrs = [:id, :owner_id, :owner_type, :app_id, :activity_type, :status, :duration_ms, :payload, :created_at]
+    attrs = [:id, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :payload, :created_at]
     @activity ||= app_activity
     @activity.select(attrs).limit(limit).order(created_at: :desc)
   end
@@ -119,7 +119,7 @@ class ActivityEntriesController < ApplicationController
   end
 
   def activity_entry_params
-    @activity_params = {}.merge(params.permit(:activity_type, :source, :status, :duration_ms))
+    @activity_params = {}.merge(params.permit(:activity_type, :source, :status, :duration_ms, :register_item_id))
     @activity_params[:payload] = JSON.parse(request.body.read)["payload"]
     @activity_params[:diagnostics] = JSON.parse(request.body.read)["diagnostics"]
     @activity_params
@@ -127,7 +127,7 @@ class ActivityEntriesController < ApplicationController
 
   # Do not permit :payload or :activity_type on update, as it would re-write history
   def activity_entry_update_params
-    @activity_params = {}.merge(params.permit(:status, :duration_ms))
+    @activity_params = {}.merge(params.permit(:status, :duration_ms, :register_item_id))
     @activity_params[:diagnostics] = JSON.parse(request.body.read)["diagnostics"]
     @activity_params
   end

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -9,6 +9,7 @@ class ActivityEntry < ApplicationRecord
   validates :source, presence: true, if: :is_request?
 
   belongs_to :app
+  belongs_to :register_item, optional: true
   belongs_to :owner, polymorphic: true
 
   before_create :generate_update_id
@@ -82,6 +83,7 @@ class ActivityEntry < ApplicationRecord
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
+      register_item_id: self.register_item_id,
       update_id: self.update_id,
       activity_type: self.activity_type,
       source: self.source,
@@ -99,6 +101,7 @@ class ActivityEntry < ApplicationRecord
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
+      register_item_id: self.register_item_id,
       activity_type: self.activity_type,
       source: self.source,
       status: self.status,
@@ -116,6 +119,7 @@ class ActivityEntry < ApplicationRecord
       owner_id: self.owner_id,
       owner_type: self.owner_type,
       app_id: self.app.name,
+      register_item_id: self.register_item_id,
       activity_type: self.activity_type,
       status: self.status,
       duration_ms: self.duration_ms,

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -13,6 +13,7 @@ class RegisterItem < ApplicationRecord
   SEARCHABLE_COLUMNS = %w[originated_at description amount units unique_key].freeze
 
   belongs_to :register
+  has_many :activity_entries
 
   @@initialized_registers = {}
   @@initialization_lock = Mutex.new

--- a/db/migrate/20240610215817_add_register_item_to_activity_entries.rb
+++ b/db/migrate/20240610215817_add_register_item_to_activity_entries.rb
@@ -1,0 +1,5 @@
+class AddRegisterItemToActivityEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :activity_entries, :register_item, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_01_150728) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_10_215817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -56,9 +56,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_01_150728) do
     t.datetime "updated_at", null: false
     t.string "owner_type"
     t.bigint "owner_id"
+    t.bigint "register_item_id"
     t.index ["app_id"], name: "index_activity_entries_on_app_id"
     t.index ["owner_type", "owner_id"], name: "index_activity_entries_on_owner"
     t.index ["payload"], name: "index_activity_entries_on_payload", using: :gin
+    t.index ["register_item_id"], name: "index_activity_entries_on_register_item_id"
     t.index ["update_id"], name: "index_activity_entries_on_update_id"
   end
 
@@ -276,6 +278,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_01_150728) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_entries", "apps"
+  add_foreign_key "activity_entries", "register_items"
   add_foreign_key "manifest_drafts", "apps"
   add_foreign_key "manifest_drafts", "manifests"
   add_foreign_key "manifests", "apps", column: "internal_app_id"


### PR DESCRIPTION
**Before**
`ActivityEntry` entry diagnostics contained information about `RegisterItem` entries, but there way no database level way of relating them.

**After**
`ActivityEntry` has a belongs_to relation with `RegisterItem`, so each `ActivityEntry` can be correctly related to a `RegisterItem` when relevant.