### PR TITLE
feature/cors-staging

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -21,6 +21,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
         'uid'
       ]
   end
-  puts "Accepting requests from Trivial UI from: #{ENV['TRIVIAL_UI_URL'] || 'No URL provided, set TRIVIAL_UI_URL to enable CORS.'}"
-
+  origins = all_resources[0].instance_variable_get(:@origins)
+  if origins.empty?
+    puts 'Not accepting requests from Trivial UI: No URL provided, set TRIVIAL_UI_URL to enable CORS'
+  else
+    puts "Accepting requests from Trivial UI from: #{ origins }"
+  end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,7 +8,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['TRIVIAL_UI_URL'] || ''
+    origins ENV['TRIVIAL_UI_URL']&.split(',') || ''
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
**Before**
Only a single `CORS` origin url was specifiable via `ENV`

**After**
`TRIVIAL_UI_URL` can accept a string of comma delimited urls as an `ENV` variable to support an array of valid `CORS` origins

**CORS Failure on localhost:5173 when no TRIVIAL_UI_URL is provided**
![Screenshot from 2024-06-17 16-14-25](https://github.com/solid-adventure/trivial-api/assets/116381228/276c972e-3348-4d0f-92cb-2224746975a0)
**CORS Success on localhost:5173 with single valid origin URL**
![Screenshot from 2024-06-17 16-13-11](https://github.com/solid-adventure/trivial-api/assets/116381228/f2543d9c-a10b-48fe-a5c0-ae6a11dc5d9a)
**CORS Failure on localhost:3000 with multiple valid origin URLs**
![Screenshot from 2024-06-17 16-12-23](https://github.com/solid-adventure/trivial-api/assets/116381228/da219907-8896-4712-bf5d-3206befbb3a0)
**CORS Success on localhost:1234 with multiple valid origin URLs**
![Screenshot from 2024-06-17 16-11-44](https://github.com/solid-adventure/trivial-api/assets/116381228/506e7aa3-9935-4b52-8200-46aa479571cf)
