### PR TITLE
enhance/jsonb-keys-retrieval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "posthog-ruby"
 gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
+gem "scenic", "~> 1.8"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,9 @@ GEM
     rswag-ui (2.9.0)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
+    scenic (1.8.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     securerandom (0.2.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
@@ -328,6 +331,7 @@ DEPENDENCIES
   rswag-api
   rswag-specs
   rswag-ui
+  scenic (~> 1.8)
   securerandom
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/activity_entry_payload_key.rb
+++ b/app/models/activity_entry_payload_key.rb
@@ -1,0 +1,9 @@
+class ActivityEntryPayloadKey < ApplicationRecord
+  def readonly?
+    true
+  end
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view('activity_entry_payload_keys', concurrently: false, cascade: false)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,8 +64,9 @@ Rails.application.routes.draw do
   resources :activity_entries, only: [:index, :create, :show, :create_from_request, :update] do
     collection do
       get 'stats'
-      get 'keys'
       get 'columns'
+      get 'keys'
+      post 'keys', action: :refresh_keys
     end
 
     member do

--- a/db/migrate/20240701191304_create_activity_entry_payload_keys.rb
+++ b/db/migrate/20240701191304_create_activity_entry_payload_keys.rb
@@ -1,0 +1,6 @@
+class CreateActivityEntryPayloadKeys < ActiveRecord::Migration[7.0]
+  def change
+    create_view :activity_entry_payload_keys, materialized: true
+    add_index :activity_entry_payload_keys, :app_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_10_215817) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_01_191304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -286,4 +286,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_215817) do
   add_foreign_key "org_roles", "users"
   add_foreign_key "permissions", "users"
   add_foreign_key "register_items", "registers"
+
+  create_view "activity_entry_payload_keys", materialized: true, sql_definition: <<-SQL
+      SELECT DISTINCT activity_entries.app_id,
+      jsonb_object_keys(activity_entries.payload) AS keys
+     FROM activity_entries
+    ORDER BY (jsonb_object_keys(activity_entries.payload));
+  SQL
+  add_index "activity_entry_payload_keys", ["app_id"], name: "index_activity_entry_payload_keys_on_app_id"
+
 end

--- a/db/views/activity_entry_payload_keys_v01.sql
+++ b/db/views/activity_entry_payload_keys_v01.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT	app_id,	jsonb_object_keys(payload) AS keys
+FROM activity_entries
+ORDER BY keys

--- a/test/models/activity_entry_payload_key_test.rb
+++ b/test/models/activity_entry_payload_key_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActivityEntryPayloadKeyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**Before**
Querying jsonb columns for distinct keys was resource intensive and failed on large data sets

**After**
- uses `Scenic` to generate and manage `views` and `materialized views`
- generated `materialized view` for distinct `payload` keys on `ActivityEntry`
- `ActivityEntryController` queries against materialized views to improve query response times
- slight clean up of `Search` module, replaced `get_keys` with `get_keys_from_path`