### PR TITLE
Feature/new interval events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'rswag-specs'
+  gem 'karafka-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,12 +148,19 @@ GEM
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
     jwt (2.7.1)
+    karafka (2.3.4)
+      karafka-core (>= 2.3.0, < 2.4.0)
+      waterdrop (>= 2.6.12, < 3.0.0)
+      zeitwerk (~> 2.3)
     karafka-core (2.3.0)
       karafka-rdkafka (>= 0.14.8, < 0.15.0)
     karafka-rdkafka (0.14.10)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
+    karafka-testing (2.3.3)
+      karafka (>= 2.3.0, < 2.4.0)
+      waterdrop (>= 2.6.12)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -318,6 +325,7 @@ DEPENDENCIES
   factory_bot_rails
   groupdate
   jwt (~> 2.3)
+  karafka-testing
   listen (~> 3.2)
   net-imap
   net-pop

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -20,13 +20,6 @@ class ActivityEntry < ApplicationRecord
     .where.not(update_id: nil)
   }
 
-  # Long-lived session shared by all requests
-  @kafka = Services::Kafka.new
-
-  def self.kafka
-    @kafka
-  end
-
   def app_runner_service
     self.class.app_runner_service
   end
@@ -153,7 +146,7 @@ class ActivityEntry < ApplicationRecord
   end
 
   def self.send_new_kafka(app, payload)
-    @kafka.produce_sync(topic: Services::Kafka.topic, payload: payload, key: JSON.parse(payload)["key"])
+    KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload, key: JSON.parse(payload)["key"])
     return OpenStruct.new(code: 200, message: 'OK')
   end
 

--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Be sure to restart your server when you modify this file.
+require "#{Rails.root}/lib/services/kafka"
+
+
+# Long-lived session shared by all requests
+KAFKA = Services::Kafka.new

--- a/lib/services/kafka.rb
+++ b/lib/services/kafka.rb
@@ -19,6 +19,11 @@ module Services
       @producer
     end
 
+    def produce_async(topic:, payload:, key:)
+      validate_payload(payload)
+      producer.produce_async(topic: topic, payload: payload, key: key)
+    end
+
     def produce_sync(topic:, payload:, key:)
       validate_payload(payload)
       producer.produce_sync(topic: topic, payload: payload, key: key)

--- a/lib/services/kafka.rb
+++ b/lib/services/kafka.rb
@@ -19,11 +19,6 @@ module Services
       @producer
     end
 
-    def produce_async(topic:, payload:, key:)
-      validate_payload(payload)
-      producer.produce_async(topic: topic, payload: payload, key: key)
-    end
-
     def produce_sync(topic:, payload:, key:)
       validate_payload(payload)
       producer.produce_sync(topic: topic, payload: payload, key: key)

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -14,7 +14,9 @@ namespace :tasks do
       payload = {
         "key": key,
         "name": "period.started",
-        "period_start": period_start,
+        "period": {
+          started_at: period_start
+        },
       }
       KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: key)
     end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -5,9 +5,8 @@ namespace :tasks do
   desc "Create Kafka events when new billing period is started"
   task :send_new_period_started_events => :environment do
     puts "Starting new period task"
-    @kafka = Services::Kafka.new
-  # // key = object_verb.customerId
-    customer_ids = Tag.where(taggable_type: "App", context: "customer_id").pluck(:name)
+  # key = object_verb.customerId
+    customer_ids = Tag.where(taggable_type: "App", context: "customer_id").pluck(:name).uniq
     customer_ids.each do |customer_id|
       key = "new-period-started.#{customer_id}"
       payload = {
@@ -15,7 +14,7 @@ namespace :tasks do
         "name": "New Period Started",
         "period_start": "#{Date.today.beginning_of_day.utc.iso8601 }" # Midnight UTC
       }
-      @kafka.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: key)
+      KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: key)
     end
   end
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -8,12 +8,12 @@ namespace :tasks do
   # key = object_verb.customerId
     customer_ids = Tag.where(taggable_type: "App", context: "customer_id").pluck(:name).uniq
     customer_ids.each do |customer_id|
-      key = "new-period-started.#{customer_id}"
+      key = "period.started.#{customer_id}"
       period_start = "#{Date.today.beginning_of_day.utc.iso8601 }" # Midnight UTC
       puts "Sending new period started event. period_start: #{period_start}, customer_id: #{customer_id}"
       payload = {
         "key": key,
-        "name": "New Period Started",
+        "name": "period.started",
         "period_start": period_start,
       }
       KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: key)

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -4,15 +4,17 @@ namespace :tasks do
   # rake tasks:send_new_period_started_events
   desc "Create Kafka events when new billing period is started"
   task :send_new_period_started_events => :environment do
-    puts "Starting new period task"
+    puts "Producing new period events into kafka topic: #{Services::Kafka.topic}"
   # key = object_verb.customerId
     customer_ids = Tag.where(taggable_type: "App", context: "customer_id").pluck(:name).uniq
     customer_ids.each do |customer_id|
       key = "new-period-started.#{customer_id}"
+      period_start = "#{Date.today.beginning_of_day.utc.iso8601 }" # Midnight UTC
+      puts "Sending new period started event. period_start: #{period_start}, customer_id: #{customer_id}"
       payload = {
         "key": key,
         "name": "New Period Started",
-        "period_start": "#{Date.today.beginning_of_day.utc.iso8601 }" # Midnight UTC
+        "period_start": period_start,
       }
       KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: key)
     end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  taggable_type: App
+  context: customer_id
+  name: 1
+
+two:
+  taggable_type: App
+  context: customer_id
+  name: 2

--- a/test/lib/services/kafka_test.rb
+++ b/test/lib/services/kafka_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class KafkaTest < ActiveSupport::TestCase
 
   def setup
-    @kafka = Services::Kafka.new
+    #
   end
 
   test 'initializes' do
-    assert_instance_of WaterDrop::Producer, @kafka.producer
+    assert_instance_of WaterDrop::Producer, KAFKA.producer
   end
 
   test 'throws when topic is not set' do
@@ -38,13 +38,13 @@ class KafkaTest < ActiveSupport::TestCase
 
   test 'throws when payload is nil' do
     assert_raises TypeError do
-      @kafka.produce_sync(topic: "events", payload: nil, key: "key")
+      KAFKA.produce_sync(topic: "events", payload: nil, key: "key")
     end
   end
 
   test 'does not throw when payload is valid' do
     assert_nothing_raised do
-      @kafka.validate_payload({key: "value"}.to_json)
+      KAFKA.validate_payload({key: "value"}.to_json)
     end
   end
 

--- a/test/lib/tasks/tasks_test.rb
+++ b/test/lib/tasks/tasks_test.rb
@@ -24,12 +24,12 @@ class RakeTaskTest < ActiveSupport::TestCase
       assert_equal Tag.where(taggable_type: "App", context: "customer_id").pluck(:name), ["1","2"]
 
       # Run the rake task and ensure the producer now has the two messages the task should have created
-      mock_enviroment(partial_env_hash:{"KAFKA_TOPIC"=>"events"}) do
+      mock_enviroment(partial_env_hash:{"KAFKA_TOPIC"=>"billing_events"}) do
         Rake::Task["tasks:send_new_period_started_events"].invoke
         assert_equal @producer.client.messages.count, 2
 
         payloads = @producer.client.messages.map {|m| JSON.parse m[:payload] }
-        assert_equal  payloads.map { |p| p["name"] }.uniq, ["New Period Started"]
+        assert_equal  payloads.map { |p| p["name"] }.uniq, ["period.started"]
       end
   end
 

--- a/test/lib/tasks/tasks_test.rb
+++ b/test/lib/tasks/tasks_test.rb
@@ -24,11 +24,13 @@ class RakeTaskTest < ActiveSupport::TestCase
       assert_equal Tag.where(taggable_type: "App", context: "customer_id").pluck(:name), ["1","2"]
 
       # Run the rake task and ensure the producer now has the two messages the task should have created
-      Rake::Task["tasks:send_new_period_started_events"].invoke
-      assert_equal @producer.client.messages.count, 2
+      mock_enviroment(partial_env_hash:{"KAFKA_TOPIC"=>"events"}) do
+        Rake::Task["tasks:send_new_period_started_events"].invoke
+        assert_equal @producer.client.messages.count, 2
 
-      payloads = @producer.client.messages.map {|m| JSON.parse m[:payload] }
-      assert_equal  payloads.map { |p| p["name"] }.uniq, ["New Period Started"]
+        payloads = @producer.client.messages.map {|m| JSON.parse m[:payload] }
+        assert_equal  payloads.map { |p| p["name"] }.uniq, ["New Period Started"]
+      end
   end
 
 end

--- a/test/lib/tasks/tasks_test.rb
+++ b/test/lib/tasks/tasks_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'rake'
+
+class RakeTaskTest < ActiveSupport::TestCase
+
+  def setup
+    # See https://karafka.io/docs/WaterDrop-Testing/#buffered-client
+    @producer = KAFKA.producer
+    @producer.config.client_class = WaterDrop::Clients::Buffered
+    @producer.client.reset
+  end
+
+  test 'kafka mock initializes' do
+    handle = @producer.produce_async(topic: 'test', payload: '123')
+    assert_equal @producer.client.messages.last, {:topic=>"test", :payload=>"123"}
+  end
+
+  test 'sends new period started events' do
+      # Load rake tasks if they aren't already
+      Api::Application.load_tasks if Rake::Task.tasks.empty?
+
+      # Confirm our starting conditions
+      assert_equal @producer.client.messages.count, 0
+      assert_equal Tag.where(taggable_type: "App", context: "customer_id").pluck(:name), ["1","2"]
+
+      # Run the rake task and ensure the producer now has the two messages the task should have created
+      Rake::Task["tasks:send_new_period_started_events"].invoke
+      assert_equal @producer.client.messages.count, 2
+
+      payloads = @producer.client.messages.map {|m| JSON.parse m[:payload] }
+      assert_equal  payloads.map { |p| p["name"] }.uniq, ["New Period Started"]
+  end
+
+end
+


### PR DESCRIPTION
**Before**
There's no mechanism to trigger calendar-based charges, such as a monthly fee.

**After**
There is a rake task available which pushes "period started" event into a Kafka stream. If this task is scheduled to run nightly, contract apps can be written to test the date and perform an action. A separate event is sent for each `customer_id` tag created for an app. This has the effect of allowing the same contract to be executed multiple times, once for each customer.

**Usage**
`rake tasks:send_new_period_started_events`

Event keys are skewer-cased with the event name, separated by a period with the customer's id, like so:
```
new-period-started.194
new-period-started.2789
new-period-started.306
```

The event payload is as follows:

```json
{
  "key": "period.started.194",
  "name": "period.started",
  "period":
  {
    "started_at": "2024-07-18T00:00:00Z"
  },
  "event_name": "period.started"
}
```
The `period.started_at` field is midnight UTC, formatted as ISO8601.
