### PR TITLE
enhance/activity_entries_index_limit

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -1,5 +1,5 @@
 class ActivityEntriesController < ApplicationController
-  MAX_RESULTS = 100
+  MAX_RESULTS = 20
 
   skip_before_action :authenticate_user!, only: [:update, :create_from_request]
 


### PR DESCRIPTION
**Before**
`ActivityEntriesController` `#index` defaulted to pulling down 100 entries

**After**
`ActivityEntriesController` `#index` defaults to 20 entries
This should speed up the response time for large payloads in a highly loaded database