### PR TITLE
enhance/materialized_key_view_v2

### DIFF
--- a/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
+++ b/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
@@ -1,0 +1,8 @@
+class UpdateActivityEntryPayloadKeysToVersion2 < ActiveRecord::Migration[7.0]
+  def change
+    replace_view :activity_entry_payload_keys,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+  end
+end

--- a/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
+++ b/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
@@ -1,6 +1,6 @@
 class UpdateActivityEntryPayloadKeysToVersion2 < ActiveRecord::Migration[7.0]
   def change
-    replace_view :activity_entry_payload_keys,
+    update_view :activity_entry_payload_keys,
       version: 2,
       revert_to_version: 1,
       materialized: true

--- a/db/views/activity_entry_payload_keys_v02.sql
+++ b/db/views/activity_entry_payload_keys_v02.sql
@@ -1,0 +1,30 @@
+WITH entry_data AS (
+	SELECT
+		app_id,
+		jsonb_object_keys(payload) AS primary_key,
+		payload
+	FROM
+		activity_entries
+),
+extracted_key_data AS (
+	SELECT
+		entry_data.app_id,
+		entry_data.primary_key,
+		secondary_key_data.secondary_key
+	FROM entry_data
+	LEFT JOIN LATERAL (
+		SELECT
+			jsonb_object_keys(entry_data.payload -> entry_data.primary_key) AS secondary_key
+		WHERE
+			jsonb_typeof(entry_data.payload -> entry_data.primary_key) = 'object'
+	) secondary_key_data ON true
+)
+SELECT DISTINCT
+	app_id,
+	primary_key,
+	secondary_key
+FROM
+	extracted_key_data
+ORDER BY
+	primary_key,
+	secondary_key


### PR DESCRIPTION
**Before**
`activity_entry_payload_keys` only contained top-level object keys

**After**
`activity_entry_payload_keys` now contains all distinct sets of app_id, top-level keys, and secondary sub-object keys if they exist