### PR TITLE
fix/activity_entry_view_migration

### DIFF
--- a/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
+++ b/db/migrate/20240710205557_update_activity_entry_payload_keys_to_version_2.rb
@@ -4,6 +4,5 @@ class UpdateActivityEntryPayloadKeysToVersion2 < ActiveRecord::Migration[7.0]
       version: 2,
       revert_to_version: 1,
       materialized: true
-    ActivityEntryPayloadKey.reset_column_information
   end
 end


### PR DESCRIPTION
**Before**
No notes on future actions, migration results in out of sync column info for the materialized view's model

**After**
- notes for deleting temporary versioning code
- column info is kept fresh by the view_version method