### PR TITLE
enhance/chart-validations

### DIFF
--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -8,15 +8,11 @@ class Chart < ApplicationRecord
   validates :name,
     presence: true,
     uniqueness: {
-      scope: %i[dashboard],
-      message: "%{value} already exists as a chart name for this dashboard"
+      scope: %i[dashboard register],
+      message: "%{value} already exists as a chart name for this dashboard and register"
     }
   validates :chart_type,
-    presence: true,
-    uniqueness: {
-      scope: %i[dashboard register],
-      message: "%{value} already exists as a chart type for this dashboard and register"
-    }
+    presence: true
   validates :color_scheme,
     presence: true
   validates :report_period,

--- a/spec/requests/charts_spec.rb
+++ b/spec/requests/charts_spec.rb
@@ -95,9 +95,9 @@ describe "Charts API", type: :request do
         {
           register_id: register.id,
           name: "Test Chart",
-          chart_type: chart_type,
+          chart_type: "test",
           color_scheme: "default",
-          report_period: "year",
+          report_period: report_period,
           report_groups: {
             customer_id: false,
             income_account: true,
@@ -106,7 +106,7 @@ describe "Charts API", type: :request do
           }
         }
       }
-      let(:chart_type) { 'test' }
+      let(:report_period) { 'year' }
 
       response '201', 'Create Dashboard Chart' do
         schema type: { '$ref' => '#/components/schemas/chart_schema' }
@@ -121,7 +121,7 @@ describe "Charts API", type: :request do
       end
 
       response '422', 'Invalid Chart Params' do
-        let(:chart_type) { 'gross_revenue' }
+        let(:report_period) { 'millisecond' }
         run_test!
       end
 


### PR DESCRIPTION
**Before**
Validations were overly restrictive in unhelpful ways

**After**
Validations allow multiple charts of the same type, more narrowly scopes name uniqueness by `register` and `dashboard`