### PR TITLE
enhance/reports-controller

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,10 +6,10 @@ class ReportsController < ApplicationController
   # POST reports/item_list
   def show
     report = Services::Report.new()
-    render json: report.__send__(params["report_name"], report_params.merge(user: current_user))
+    render json: report.__send__(report_name, report_params.merge(user: current_user))
   rescue ArgumentError => e
     Rails.logger.error e
-    render json: {error: e.message}, status: :unprocessable_content
+    render json: {error: e.message}, status: :unprocessable_entity
   rescue => e
     Rails.logger.error e
     render json: {error: "Unable to render report"}, status: :internal_server_error
@@ -17,5 +17,13 @@ class ReportsController < ApplicationController
 
   def report_params
     params.permit(:start_at, :end_at, :register_id, :group_by_period, :timezone, group_by: [])
+  end
+
+  ALLOWED_REPORTS = %w[ item_sum item_average item_count ].freeze
+  def report_name
+    unless ALLOWED_REPORTS.include? params["report_name"]
+      raise ArgumentError, "unpermitted report: #{params[:report_name]}"
+    end
+    params["report_name"]
   end
 end

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -12,20 +12,6 @@ module Services
       simple_stat_lookup("average", args)
     end
 
-    def item_list(args)
-      raise ArgumentError, 'Invalid start_at' unless args[:start_at]
-      raise ArgumentError, 'Invalid end_at' unless args[:end_at]
-      raise ArgumentError, 'Invalid register_id' unless args[:register_id]
-      limit = args[:limit] || 50
-
-      results = args[:user].associated_register_items
-        .where(register_id: args[:register_id])
-        .between(args[:start_at], args[:end_at])
-
-      # TODO: output formatted fot TableView
-      {title: "All Items", count: results.limit(limit) }
-    end
-
     private
 
     def simple_stat_lookup(stat, args)

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+require 'swagger_helper'
+
+describe "Reports API", type: :request do
+  let(:user) { FactoryBot.create(:user, :logged_in) }
+  let(:client) { user.tokens.keys.first }
+  let('access-token') { user.tokens[client]['token_unhashed'] }
+  let(:uid) { user.uid }
+  let(:organization) { FactoryBot.create :organization, admin: user }
+  let!(:register) { organization.owned_registers.first }
+  let!(:register_item) { FactoryBot.create(:register_item, register: register, originated_at: start_at + 1.day) }
+
+  let(:report_params) {
+    {
+      start_at: start_at.iso8601,
+      end_at: end_at.iso8601,
+      register_id: register.id,
+    }
+  }
+  let(:start_at) { Time.new(2022,1,1) }
+  let(:end_at) { start_at + 2.years - 1.second }
+
+  def self.report_schema
+    {
+      type: :object,
+      properties: {
+        title: { type: String },
+        count: {
+          type: :array,
+          items: {
+            type: :object,
+            properties: {
+              period: { type: String },
+              group: { type: String },
+              value: { type: Float }
+            },
+            required: %w[period group value]
+          }
+        }
+      },
+      required: %w[title count]
+    }
+  end
+
+  def self.report_request_schema
+    {
+      type: :object,
+      properties: {
+        start_at: { type: String },
+        end_at: { type: String },
+        register_id: { type: Integer },
+        group_by_period: { type: String },
+        timezone: { type: String },
+        group_by: {
+          type: :array,
+          items: { type: String }
+        },
+      },
+      required: %w[start_at end_at register_id]
+    }
+  end
+
+  path 'reports/item_count' do
+    post "count of items in register" do
+      tags 'Reports'
+      security [ { access_token: [], client: [], uid: [] } ]
+      consumes 'application/json'
+      produces  'report/json'
+
+      parameter name: :report_params, in: :body, schema: report_request_schema
+
+      response '200', 'Show Item Count' do
+        schema type: report_schema
+        run_test!
+      end
+    end
+  end
+
+  path 'reports/item_average' do
+    post "average item amounts for register" do
+      tags 'Reports'
+      security [ { access_token: [], client: [], uid: [] } ]
+      consumes 'application/json'
+      produces  'report/json'
+
+      parameter name: :report_params, in: :body, schema: report_request_schema
+
+      response '200', 'Show Items Average' do
+        schema type: report_schema
+        run_test!
+      end
+    end
+  end
+
+  path 'reports/item_sum' do
+    post "sum of item amounts for register" do
+      tags 'Reports'
+      security [ { access_token: [], client: [], uid: [] } ]
+      consumes 'application/json'
+      produces  'report/json'
+
+      parameter name: :report_params, in: :body, schema: report_request_schema
+
+      response '200', 'Show Items Sum' do
+        schema type: report_schema
+        run_test!
+      end
+    end
+  end
+
+  path 'reports/delete' do
+    post "invalid report_name" do
+      tags 'Reports'
+      security [ { access_token: [], client: [], uid: [] } ]
+      consumes 'application/json'
+      produces  'report/json'
+
+      parameter name: :report_params, in: :body, schema: report_request_schema
+
+      response '422', 'invalid report' do
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Before**
No guards against code injection in `Reports` controller

**After**
- Only allowed report types are passed to `__send__`
- fixed status in render for report errors
- remove `item_list` from `Report` model
- added simple test for `Report` end-points