### PR TITLE
enhance/organizations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,7 @@ class Organization < ApplicationRecord
   has_many :owned_register_items, class_name: 'RegisterItem', as: :owner
   has_many :owned_dashboards, class_name: 'Dashboard', as: :owner, inverse_of: :owner
 
-  has_many :org_roles, dependent: :delete_all
+  has_many :org_roles, dependent: :destroy
   has_many :users, through: :org_roles
 
   validates :billing_email, presence: true
@@ -18,6 +18,8 @@ class Organization < ApplicationRecord
 
   after_create :create_default_dashboard
   after_create :create_default_register
+
+  default_scope { order(created_at: :asc) }
 
   private
     def create_default_register

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,15 +1,25 @@
 class OrganizationSerializer < ActiveModel::Serializer
   attributes :id, :name, :billing_email
-  has_many :users, if: -> { instance_options[:include_users] }
- 
-  def users
-    object.users.map do |user|
-      {
-        user_id: user.id,
-        name: user.name,
-        email: user.email,
-        role: user.org_roles.find_by(organization_id: object.id).role
-      }
+  has_many :org_roles, key: :users, if: -> { instance_options[:include_users] }
+  has_many :owned_dashboards, key: :dashboards
+
+  class OrgRoleSerializer < ActiveModel::Serializer
+    attributes :id, :name, :email, :role
+
+    def id
+      object.user.id
     end
+
+    def name
+      object.user.name
+    end
+
+    def email
+      object.user.email
+    end
+  end
+
+  class DashboardSerializer < ActiveModel::Serializer
+    attributes :id, :name
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,13 +19,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :organizations do
-    member do
-      post 'create_org_role'
-      put 'update_org_role'
-      delete 'delete_org_role'
-    end
-  end
+  resources :organizations
 
   resources :apps, only: [:index, :create, :update, :show, :destroy] do
 


### PR DESCRIPTION
**Before**
Organization model, controller, and serializer were slightly out of date with current usage

**After**
- added `default_scope` ordering to ensure stable ordering in responses
- adjusted serializer to include `dashboards` and use conventional serialization method
- removed non-RESTful `org_role` methods and routes from `Organization` controller and routes
- changed `org_role` dependency callback to the safer `destroy` method

**Notes**
- We don't currently use the `org_role` routes currently and opt for an invitation strategy instead. Future re-implentation of similar routes should use RESTful routing conventions such as nested resource routing
- API serialization changes are non-breaking because they maintain currently used API response formats
- Tested against the current `main` branch of `trivial-ui`