### PR TITLE
enhance/chart-defaults

### DIFF
--- a/db/migrate/20240801001645_change_default_chart_type_in_charts.rb
+++ b/db/migrate/20240801001645_change_default_chart_type_in_charts.rb
@@ -1,0 +1,7 @@
+class ChangeDefaultChartTypeInCharts < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :charts, :chart_type, 'table'
+
+    Chart.where(chart_type: 'gross_revenue').update_all(chart_type: 'table')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_16_212314) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_01_001645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -111,7 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_16_212314) do
     t.bigint "dashboard_id", null: false
     t.bigint "register_id", null: false
     t.string "name", null: false
-    t.string "chart_type", default: "gross_revenue", null: false
+    t.string "chart_type", default: "table", null: false
     t.string "color_scheme", default: "default", null: false
     t.string "report_period", null: false
     t.boolean "meta0"


### PR DESCRIPTION
**Before**
`gross_revenue` is more a chart name than a type, we mean things like `line_graph`, `bar_graph`, `heat_map`, `table`, etc.

**After**
`chart_type` defaults to `table` which is more in line with how we'll use it