### PR TITLE
feature/activity-entry-cleanup-task

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1,6 +1,4 @@
 namespace :tasks do
-
-
   # rake tasks:send_new_period_started_events
   desc "Create Kafka events when new billing period is started"
   task :send_new_period_started_events => :environment do
@@ -62,25 +60,26 @@ namespace :tasks do
     puts "Done"
   end
 
-  desc "Create Sign Up events in PostHog for existing users"
-  task backfill_user_signups: :environment do
+  # rake "tasks:cleanup_activity_entries["30"]" this will run in non-destructive preview mode
+  # rake "tasks:cleanup_activity_entries["30","false"]" this will actually delete records
+  desc "Remove ActivityEntries with no RegisterItem that are older than provided days"
+  task :cleanup_activity_entries, [:days_kept, :preview] => :environment do |t, args|
+    raise 'must supply number of days to keep' unless args[:days_kept]
+    cutoff_date = Time.now - args[:days_kept].to_i.days
+    puts "Preparing to remove outdated ActivityEntries, current cutoff date is #{cutoff_date}."
 
-    posthog = PostHog::Client.new({
-      api_key: ENV['POSTHOG_API_KEY'],
-      api_host: ENV['POSTHOG_HOST'],
-      on_error: Proc.new { |status, msg| print msg }
-    })
+    preview = ActiveModel::Type::Boolean.new.cast(args[:preview])
+    preview = true if preview.nil?
 
-    User.where("created_at > ?", Time.now - 7.day).each do |user|
-      puts posthog.capture({
-        distinct_id: user.email,
-        event: 'User Signup',
-        properties: {
-            source: 'backfill_user_signups',
-        },
-        timestamp: user.created_at
-      })
+    entries_to_delete = ActivityEntry.where(register_item_id: nil)
+                                     .where('created_at < ?', cutoff_date)
+    puts "#{entries_to_delete.count} ActivityEntries to delete."
+
+    if preview
+      puts "Preview Mode, would have deleted #{entries_to_delete.count}"
+    else
+      deleted_count = entries_to_delete.destroy_all.length
+      puts "Deleted #{deleted_count} ActivityEntry records"
     end
   end
-
 end

--- a/spec/factories/activity_entry.rb
+++ b/spec/factories/activity_entry.rb
@@ -3,6 +3,25 @@ FactoryBot.define do
   factory :activity_entry do
     association :owner, factory: :user
     app { FactoryBot.create(:app, owner: owner) }
+    activity_type { 'test' }
+    status { '200' }
+    source { 'localhost' }
+    duration_ms { rand(200..5000) }
+    sequence :payload do |n|
+      {
+        key: "unique-key-#{n}",
+        event_name: "test-event-#{n}",
+        event: {
+          id: n,
+        }
+      }
+    end
+    diagnostics {
+      {
+        errors: [],
+        events: []
+      }
+    }
 
     trait :org_owner do
       association :owner, factory: :organization

--- a/spec/lib/tasks/tasks_spec.rb
+++ b/spec/lib/tasks/tasks_spec.rb
@@ -1,0 +1,54 @@
+# spec/lib/tasks/tasks_spec.rb
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'activity_entries:cleanup', type: :task do
+  before :all do
+    Rake.application = Rake::Application.new
+    Rake.application.rake_require('tasks/tasks')
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['tasks:cleanup_activity_entries'] }
+  let(:owner) { FactoryBot.create :organization }
+  let(:register) { owner.owned_registers.first }
+  let(:app) { FactoryBot.create :app, owner: owner }
+
+  before do
+    @old_kept_entry = FactoryBot.create(
+      :activity_entry,
+      app: app,
+      created_at: 8.days.ago,
+      register_item: FactoryBot.create(:register_item, register: register)
+    )
+    @recent_kept_entry = FactoryBot.create(
+      :activity_entry,
+      app: app,
+      register_item: FactoryBot.create(:register_item, register: register)
+    )
+    @recent_deleteable_entry = FactoryBot.create :activity_entry, app: app
+  end
+
+  it 'deletes ActivityEntries with nil register_item_id older than 7 days and not in preview mode' do
+    @old_deleteable_entry = FactoryBot.create :activity_entry, app: app, created_at: 8.days.ago
+
+    expect { task.invoke('7', 'false') }.to change { ActivityEntry.count }.by(-1)
+
+    # Ensure only the correct entries were deleted
+    expect(ActivityEntry.exists?(@recent_kept_entry.id)).to be true
+    expect(ActivityEntry.exists?(@old_kept_entry.id)).to be true
+    expect(ActivityEntry.exists?(@recent_deleteable_entry.id)).to be true
+    expect(ActivityEntry.exists?(@old_deleteable_entry.id)).to be false
+  end
+
+  it 'does nothing if there are no matching ActivityEntries' do
+    task.reenable
+    expect { task.invoke('7', 'false') }.not_to change { ActivityEntry.count }
+  end
+
+  it 'uses preview mode by default' do
+    task.reenable
+    @old_deleteable_entry = FactoryBot.create :activity_entry, app: app, created_at: 8.days.ago
+    expect { task.invoke('7') }.not_to change { ActivityEntry.count }
+  end
+end


### PR DESCRIPTION
Creates a tasks for cleaning up activity entries based on age and whether they created a register item.
Task accepts variables for number of days and whether to turn off preview mode.
Includes Rspec tests