### PR TITLE
feature/invert_report_sign

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -16,7 +16,7 @@ class ReportsController < ApplicationController
   end
 
   def report_params
-    params.permit(:start_at, :end_at, :register_id, :group_by_period, :timezone, group_by: [])
+    params.permit(:start_at, :end_at, :register_id, :invert_sign, :group_by_period, :timezone, group_by: [])
   end
 
   ALLOWED_REPORTS = %w[ item_sum item_average item_count ].freeze

--- a/db/migrate/20240820161314_add_sign_change_to_charts.rb
+++ b/db/migrate/20240820161314_add_sign_change_to_charts.rb
@@ -1,0 +1,5 @@
+class AddSignChangeToCharts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charts, :invert_sign, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_01_001645) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_20_161314) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -126,6 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_01_001645) do
     t.boolean "meta9"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "invert_sign", default: false, null: false
     t.index ["chart_type"], name: "index_charts_on_chart_type"
     t.index ["dashboard_id"], name: "index_charts_on_dashboard_id"
     t.index ["register_id"], name: "index_charts_on_register_id"

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -49,6 +49,29 @@ RSpec.describe Services::Report do
       expect(results[:count].first[:value]).to eq(1)
     end
 
+    it "does not invert amount's sign by default" do
+      results = report.send(:simple_stat_lookup, 'sum', args)
+      expect(results[:count].first[:value]).to eq(5.0)
+    end
+
+    it "inverts amount's sign when invert_sign is true" do
+      args[:invert_sign] = true
+      results = report.send(:simple_stat_lookup, 'sum', args)
+      expect(results[:count].first[:value]).to eq(-5.0)
+    end
+
+    it "correctly inverts amount's sign when grouping" do
+      args[:group_by] = ['income_account']
+      results = report.send(:simple_stat_lookup, 'sum', args)
+      expect(results[:count][0][:value]).to eq(2.5)
+      expect(results[:count][1][:value]).to eq(2.5)
+
+      args[:invert_sign] = true
+      results = report.send(:simple_stat_lookup, 'sum', args)
+      expect(results[:count][0][:value]).to eq(-2.5)
+      expect(results[:count][1][:value]).to eq(-2.5)
+    end
+
     it 'correctly groups results given a :group_by' do
       args[:group_by] = ['entity_type']
       results = report.send(:simple_stat_lookup, 'count', args)


### PR DESCRIPTION
**Before**
Some user needed to invert the sign of reports for their charts but had no option to do so

**After**
- `Charts` have boolean column to hold `invert_sign` option which determines if that `Chart's` `Reports` will have inverted `amounts`
- `Reports` end-point accept `invert_sign` option
- `Reports` multiply all `amounts` by -1 if `invert_sign` true