### PR TITLE
Feature/csv export

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -149,9 +149,8 @@ class RegisterItemsController < ApplicationController
   end
 
   def set_streaming_headers
-    #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
     headers['X-Accel-Buffering'] = 'no'
-
+    headers["Last-Modified"] = Time.now.httpdate.to_s
     headers["Cache-Control"] ||= "no-cache"
     headers.delete("Content-Length")
   end

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -1,4 +1,5 @@
 require 'search'
+require 'csv'
 
 class RegisterItem < ApplicationRecord
 
@@ -42,6 +43,43 @@ class RegisterItem < ApplicationRecord
 
   def resolved_column(label)
     RegisterItem.resolved_column(label, register.meta)
+  end
+
+  def to_csv_row(meta_symbols=[], meta_db_column_names=[])
+    header = self.class.csv_header(meta_symbols)
+    values = [
+      "id",
+      "register_id",
+      "owner_type",
+      "owner_id",
+      "unique_key",
+      "description",
+      "amount",
+      "units",
+      "originated_at",
+      "created_at"
+    ]
+    .concat(meta_db_column_names)
+    values = values.map { |value| self[value] }
+    CSV::Row.new(header, values, false) #false - means its not a header
+  end
+
+  def self.csv_header(meta_symbols=[])
+    symbols = [
+        :id,
+        :register_id,
+        :owner_type,
+        :owner_id,
+        :unique_key,
+        :description,
+        :amount,
+        :units,
+        :originated_at,
+        :created_at
+      ]
+    symbols += meta_symbols
+    names = symbols.map { |s| s.to_s }
+    CSV::Row.new(symbols, names, true)  #true - means its a header
   end
 
   def self.resolved_column(label, column_labels)


### PR DESCRIPTION
**Before**
No ability to export CSV

**After**
Streaming CSV endpoint that respects gateway timeouts and memory.


Note: the design here is heavily influenced to avoid various N+1ish pitfalls to keep it performant, and cannot be changed without respect for these.

- [x] Respect the `MAX_PER_PAGE` setting in the non-CSV path. The CSV option is effectively limitless.
- [x] Ensure meta column mappings respect a change in sequence, and are not coincidentally correct.