### PR TITLE
enhance/cleanup_tests

### DIFF
--- a/spec/concerns/ownable_spec.rb
+++ b/spec/concerns/ownable_spec.rb
@@ -6,7 +6,7 @@ describe Ownable do
   let(:user3) { FactoryBot.create(:user) }
   let(:organization1) { FactoryBot.create(:organization, admin: user1, members_count: 2) }
   let(:organization2) { FactoryBot.create(:organization, admin: user2, members_count: 2) }
-  let(:ownable) { FactoryBot.create(:app, custom_owner: old_owner) }
+  let(:ownable) { FactoryBot.create(:app, owner: old_owner) }
 
   describe '#transfer_ownership' do
     describe "previous permissions" do
@@ -78,7 +78,7 @@ describe Ownable do
     context 'resource owner is User' do
       before do
         @owner = FactoryBot.create(:user)
-        @ownable = FactoryBot.create(:app, custom_owner: @owner)
+        @ownable = FactoryBot.create(:app, owner: @owner)
       end
 
       it 'returns true if user is owner' do
@@ -92,7 +92,7 @@ describe Ownable do
     context 'resource owner is Organization' do
       before do
         @org = FactoryBot.create(:organization, members_count: 1)
-        @ownable = FactoryBot.create(:app, custom_owner: @org)
+        @ownable = FactoryBot.create(:app, owner: @org)
       end
 
       it 'returns true if user is admin of org' do

--- a/spec/controllers/apps_spec.rb
+++ b/spec/controllers/apps_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AppsController, :type => :controller do
 
   context "logged in user" do
 
-    let! (:app) { FactoryBot.create(:app, custom_owner: user) }
+    let! (:app) { FactoryBot.create(:app, owner: user) }
 
     before do
       login
@@ -38,7 +38,7 @@ RSpec.describe AppsController, :type => :controller do
 
   context "tagged apps" do
 
-    let!(:tagged_app) { FactoryBot.create(:app, custom_owner: user) }
+    let!(:tagged_app) { FactoryBot.create(:app, owner: user) }
     let!(:tag) { FactoryBot.create(:tag, taggable: tagged_app, context: 'color', name: 'blue') }
 
     before do

--- a/spec/factories/activity_entry.rb
+++ b/spec/factories/activity_entry.rb
@@ -2,26 +2,25 @@ FactoryBot.define do
 
   factory :activity_entry do
     association :owner, factory: :user
-    app { FactoryBot.create(:app, user: user) }
-  end
+    app { FactoryBot.create(:app, owner: owner) }
 
-  trait :org_owner do
-    association :owner, factory: :organization
-  end
+    trait :org_owner do
+      association :owner, factory: :organization
+    end
 
-  trait :request do
-    activity_type { 'request' }
-    status { '200' }
-    source { 'localhost' }
-    duration_ms { 1503 }
-    payload { {"test_data" => "12345" } }
-    diagnostics { { "errors" => [], "events" => [] } }
-  end
+    trait :request do
+      activity_type { 'request' }
+      status { '200' }
+      source { 'localhost' }
+      duration_ms { 1503 }
+      payload { {"test_data" => "12345" } }
+      diagnostics { { "errors" => [], "events" => [] } }
+    end
 
-  trait :build do
-    activity_type { 'build' }
-    status { 'success' }
-    duration_ms { 2839 }
+    trait :build do
+      activity_type { 'build' }
+      status { 'success' }
+      duration_ms { 2839 }
+    end
   end
-
 end

--- a/spec/factories/app.rb
+++ b/spec/factories/app.rb
@@ -4,25 +4,8 @@ FactoryBot.define do
     association :owner, factory: :user
     sequence(:descriptive_name) {|n| "Test App \##{n}"}
 
-    transient do
-      custom_owner { nil }
-    end
-
-    before(:create) do |app, evaluator|
-      app.owner = evaluator.custom_owner if evaluator.custom_owner
-    end
-
     trait :org_owner do
       association :owner, factory: :organization
-    end
-
-    after(:create) do |app, _evaluator|
-      if app.owner.is_a?(Organization)
-        app.grant(
-          user_ids: app.owner.org_roles.where(role: 'member').pluck(:user_id),
-          permit: :read
-        )
-      end
     end
   end
 end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -7,7 +7,7 @@ describe 'Apps API' do
   let(:client) { user.tokens.keys.first }
   let(:expiry) { user.tokens[client]['expiry'] }
   let(:uid) { user.uid }
-  let!(:user_app) { FactoryBot.create(:app, custom_owner: user) }
+  let!(:user_app) { FactoryBot.create(:app, owner: user) }
 
   def self.app_schema
     {


### PR DESCRIPTION
**Before**
`rspec` tests used transients instead of passing directly to attributes with `apps` and `activity_entries`

**After**
removed unneeded transients and callbacks, passes custom values directly to attributes