### PR TITLE
enhance/charts-invert-sign-api

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -66,7 +66,7 @@ class ChartsController < ApplicationController
     end
 
     def chart_params
-      params.require(:chart).permit(:register_id, :name, :chart_type, :color_scheme, :report_period)
+      params.require(:chart).permit(:register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period)
     end
 
     # this is an aliased parameter for several underlying chart columns

--- a/app/serializers/chart_serializer.rb
+++ b/app/serializers/chart_serializer.rb
@@ -1,5 +1,5 @@
 class ChartSerializer < ActiveModel::Serializer
-  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :report_period, :report_groups
+  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period, :report_groups
 
   def report_groups
     object.aliased_groups()


### PR DESCRIPTION
**Before**
No way to save or render `invert_sign` field for `Chart`

**After**
`Chart` API end-points accept `invert_sign` param
`Chart` serializer renders `invert_sign`