### PR TITLE
fix/report-null-groups

### DIFF
--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -82,6 +82,11 @@ module Services
                         else
                           ['All', 'All'] # this shouldn't be possible
                         end
+        group = if group.is_a?(Array)
+                  group.map { |entry| entry.nil? ? '' : entry }
+                else
+                  group.nil? ? '' : group
+                end
         {
           period: period,
           group: group,


### PR DESCRIPTION
**Before**
report groups sometimes render with null values that were problematic

**After**
report groups render an empty string instead of null where relevant