### PR TITLE
feature/audits-api

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,0 +1,52 @@
+class AuditsController < ApplicationController
+  before_action :load_and_authorize_auditable
+  before_action :load_and_authorize_audit, only: %i[show]
+  before_action :set_pagination, only: %i[index]
+
+  def index
+    @audits = @auditable.own_and_associated_audits
+    paginate_audits
+    response = {
+      current_page: @page,
+      total_pages: @total_pages,
+      audits: @audits.as_json(except: %i[user_type username audited_changes comment request_uuid])
+    }
+
+    render json: response, status: :ok
+  end
+
+  def show
+    render json: @audit, root: :audit, status: :ok
+  end
+
+  private
+  MAX_PER_PAGE = 100.freeze
+
+  def load_and_authorize_auditable
+    resource, id = request.path.split('/')[1,2]
+    @auditable = resource.singularize.classify.constantize.find(id)
+
+    raise CanCan::AccessDenied unless @auditable.admin?(current_user)
+  end
+
+  def load_and_authorize_audit
+    @audit = Audited::Audit.find(params[:id])
+
+    raise CanCan::AccessDenied unless @audit.auditable == @auditable || @audit.associated == @auditable
+  end
+
+  def set_pagination
+    @per_page = params[:per_page] ? params[:per_page].to_i : MAX_PER_PAGE
+    @per_page = [@per_page, MAX_PER_PAGE].min
+    @page = params[:page] ? params[:page].to_i : 1
+  end
+
+  def paginate_audits
+    raise 'invalid per_page param' unless @per_page.positive?
+    raise 'invalid page param' unless @page.positive?
+
+    @total_pages = (@audits.count.to_f / @per_page).ceil
+    offset = (@page - 1) * @per_page
+    @audits = @audits.limit(@per_page).offset(offset)
+  end
+end

--- a/app/models/org_role.rb
+++ b/app/models/org_role.rb
@@ -1,7 +1,7 @@
 class OrgRole < ApplicationRecord
   ROLES = %w(admin member guest).freeze
 
-  audited
+  audited associated_with: :organization
 
   validates :user_id, presence: true
   validates :organization_id, presence: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,6 @@
 class Organization < ApplicationRecord
   audited
+  has_associated_audits
 
   has_many :owned_apps, class_name: 'App', as: :owner
   has_many :owned_manifests, class_name: 'Manifest', as: :owner

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -4,6 +4,7 @@ class Register < ApplicationRecord
   include Permissible
 
   audited
+  has_associated_audits
 
   # Register identity basics
   validates :name, presence: true, uniqueness: { scope: :owner }

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -7,7 +7,7 @@ class RegisterItem < ApplicationRecord
   include Permissible
   include Search
 
-  audited
+  audited associated_with: :register
 
   # includes only non-meta searchable columns
   # meta columns are handled by self.search

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@ class TagExists < StandardError
 end
 
 class Tag < ApplicationRecord
-  audited
+  audited associated_with: :taggable
 
   belongs_to :taggable, polymorphic: true
   

--- a/app/serializers/audit_serializer.rb
+++ b/app/serializers/audit_serializer.rb
@@ -1,0 +1,4 @@
+class AuditSerializer < ActiveModel::Serializer
+  attributes :id, :auditable_id, :auditable_type, :associated_id, :associated_type, :user_id,
+    :action, :audited_changes, :version, :remote_address, :created_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  concern :auditable do
+    resources :audits, only: [:index, :show]
+  end
+
   resources :customers
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
@@ -19,13 +23,20 @@ Rails.application.routes.draw do
   end
 
   resources :users
+
   resources :organizations do
     member do
       delete 'delete_org_role'
     end
   end
 
-  resources :apps, only: [:index, :create, :update, :show, :destroy] do
+  resources :apps, concerns: :auditable, only: [:index, :create, :update, :show, :destroy] do
+    collection do
+      get 'name_suggestion'
+      get 'stats/hourly'
+      get 'stats/daily'
+      get 'stats/weekly'
+    end
 
     member do 
       post 'copy'
@@ -33,17 +44,13 @@ Rails.application.routes.draw do
       post 'tags'
       delete 'tags', to: 'apps#remove_tags'
     end
+
     resource :credentials, only: [:show] do
       put '', action: :update
       patch '', action: :patch
     end
+
     resource :api_key, only: [:create, :update]
-    collection do
-      get 'name_suggestion'
-      get 'stats/hourly'
-      get 'stats/daily'
-      get 'stats/weekly'
-    end
   end
 
 

--- a/spec/requests/audits_spec.rb
+++ b/spec/requests/audits_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+require 'swagger_helper'
+
+describe "Audits API", type: :request do
+  let(:user) { FactoryBot.create(:user, :logged_in) }
+  let(:client) { user.tokens.keys.first }
+  let('access-token') { user.tokens[client]['token_unhashed'] }
+  let(:uid) { user.uid }
+  let(:organization) { FactoryBot.create :organization, admin: user }
+  let(:auditable_app) { FactoryBot.create :app, owner: organization }
+
+  def self.index_audits_schema
+    {
+      type: :object, 
+      properties: {
+        page: { type: :integer },
+        total_pages: { type: :integer },
+        audits: {
+          type: :array,
+          items: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              auditable_id: { type: :integer },
+              auditable_type: { type: :string },
+              associated_id: { type: :integer },
+              associated_type: { type: :string },
+              user_id: { type: :integer },
+              action: { type: :string },
+              version: { type: :integer },
+              remote_address: { type: :string },
+              created_at: { type: :string }
+            },
+            required: %w[id auditable_id auditable_type associated_id associated_type user_id action version remote_address created_at]
+          }
+        },
+        required: %w[page total_pages audits]
+      }
+    }
+  end
+
+  def self.show_audit_schema
+    {
+      type: :object,
+      properties: {
+        id: { type: :integer },
+        auditable_id: { type: :integer },
+        auditable_type: { type: :string },
+        associated_id: { type: :integer },
+        associated_type: { type: :string },
+        user_id: { type: :integer },
+        action: { type: :string },
+        audited_changes: {
+          type: :object,
+          additionalProperties: {
+            oneOf: []
+          }
+        },
+        version: { type: :integer },
+        remote_address: { type: :string },
+        created_at: { type: :string }
+      },
+      required: %w[id auditable_id auditable_type associated_id associated_type user_id action audited_changes version remote_address created_at]
+    }
+  end
+
+  before do
+    @auditable = auditable_app
+  end
+
+  path '{auditable_type}/{auditable_id}/audits' do
+    parameter name: 'auditable_type', in: :path, type: :string
+    parameter name: 'auditable_id', in: :path, type: :integer
+
+    let(:auditable_type) { @auditable.class.to_s.tableize }
+    let(:auditable_id) { @auditable.id }
+
+    get "list resource's audits" do
+      tags 'Audits'
+      security [ { access_token: [], client: [], uid: [] } ]
+      produces 'audit/json'
+
+      response '200', 'Index Resource Audits' do
+        schema type: :index_audit_schema
+
+        before do
+          @associated_auditable = FactoryBot.create(:manifest, app: auditable_app)
+        end
+
+        run_test! do |response|
+          data = JSON.parse response.body
+
+          audits = data['audits']
+          expect(audits.count).to eq(2)
+          expect(audits[0]['auditable_type']).to eq(@associated_auditable.class.to_s)
+          expect(audits[0]['auditable_id']).to eq(@associated_auditable.id)
+          expect(audits[0]['associated_type']).to eq(@auditable.class.to_s)
+          expect(audits[0]['associated_id']).to eq(@auditable.id)
+          expect(audits[0]['action']).to eq('create')
+          expect(audits[1]['auditable_type']).to eq(@auditable.class.to_s)
+          expect(audits[1]['auditable_id']).to eq(@auditable.id)
+          expect(audits[1]['action']).to eq('create')
+        end
+      end
+
+      response '401', 'Unauthorized User' do
+        before do
+          @auditable = FactoryBot.create :app
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path '{auditable_type}/{auditable_id}/audits/{audit_id}' do
+    parameter name: 'auditable_type', in: :path, type: :string
+    parameter name: 'auditable_id', in: :path, type: :integer
+    parameter name: 'audit_id', in: :path, type: :integer
+
+    let(:auditable_type) { @auditable.class.to_s.tableize }
+    let(:auditable_id) { @auditable.id }
+    let(:audit_id) { @audit.id }
+
+    before do
+      @audit = @auditable.audits.first
+    end
+
+    get "show resource's audit" do
+      tags 'Audits'
+      security [ { access_token: [], client: [], uid: [] } ]
+      produces 'audit/json'
+
+      response '200', "show audit for resource" do
+        schema type: :show_audit_schema
+
+        run_test! do |response|
+          data = JSON.parse response.body
+
+          audit = data['audit']
+          expect(audit['id']).to eq(@audit.id)
+          expect(audit['auditable_type']).to eq(@auditable.class.to_s)
+          expect(audit['auditable_id']).to eq(@auditable.id)
+        end
+      end
+
+      response '401', 'unauthorized user for audit' do
+        before do
+          @auditable = FactoryBot.create :app
+        end
+
+        run_test!
+      end
+
+      response '401', "unauthorized to view another resource's audit" do
+        before do
+          @other_auditable = FactoryBot.create(:app, owner: organization)
+          @audit = @other_auditable.audits.first
+        end
+
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Before**
No way to access audits via the API

**After**
`audits` controller and serializer created
`audits` route concern created
`audits` concern added to `apps` route
associated audited resources
tests for `audits` api