### PR TITLE
remove large payload column from index endpoint

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -127,7 +127,7 @@ class ActivityEntriesController < ApplicationController
 
   private
   def activity_for_index
-    attrs = [:id, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :payload, :created_at]
+    attrs = [:id, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :created_at]
     @activity ||= app_activity
     @activity.select(attrs).limit(limit).order(created_at: :desc)
   end

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -116,7 +116,6 @@ class ActivityEntry < ApplicationRecord
       activity_type: self.activity_type,
       status: self.status,
       duration_ms: self.duration_ms,
-      payload: self.payload,
       created_at: self.created_at,
     }
   end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -34,9 +34,8 @@ describe 'Webhooks API' do
         update_id: { type: :string, nullable: true },
         activity_type: { type: :string },
         status: { type: :string, nullable: true },
-        payload: { type: :object, nullable:true },
         diagnostics: { type: :object, nullable: true }
-      }, required: ['app_id', 'payload']
+      }, required: ['app_id']
     }
   end
 


### PR DESCRIPTION
**Before**
payload column is return on calls to `activity_entries#index`, which is an expensive DB query

**After**
payload column is only returned on `activity_entries#show`