### PR TITLE
enhance/manifest content

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -39,7 +39,7 @@ class ManifestsController < ApplicationController
     end
 
     def manifest_params
-        params.permit(:app_id, :content, :bundle)
+        params.permit(:app_id, :bundle, :content, content: {})
     end
 
     def app

--- a/spec/requests/manifests_spec.rb
+++ b/spec/requests/manifests_spec.rb
@@ -1,26 +1,37 @@
+require 'rails_helper'
 require 'swagger_helper'
 
 # describe 'Apps API' do
 describe 'manifests', type: :request do
 
   let(:user) { FactoryBot.create(:user, :logged_in) }
-  let('access-token') { user.tokens[client]['token_unhashed'] }
   let(:client) { user.tokens.keys.first }
-  let(:expiry) { user.tokens[client]['expiry'] }
+  let('access-token') { user.tokens[client]['token_unhashed'] }
   let(:uid) { user.uid }
 
   let!(:user_app) { FactoryBot.create(:app, owner: user ) }
   let!(:user_manifest) { FactoryBot.create(:manifest, custom_app: user_app) }
 
-  path '/manifests?app_id={appId}' do
-    get('list manifests') do
+  def self.manifest_schema
+    {
+      type: :object,
+      properties: {
+        app_id: { type: :string },
+        content: { type: :object }
+      }
+    }
+  end
 
-      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
-      produces 'application/json'
-      parameter name: "appId", in: :path, type: :string
+  path '/manifests?app_id={app_id}' do
+    parameter name: 'app_id', in: :path, type: :string
+    let(:app_id) { user_app.name }
 
-      response(200, 'successful') do
-        let(:appId) { user_app.name }
+    get 'list manifests' do
+      tags 'Manifests'
+      security [ { access_token: [], client: [], uid: [] } ]
+      produces 'manifest/json'
+
+      response '200', 'successful' do
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data.length).to eq 1
@@ -28,8 +39,8 @@ describe 'manifests', type: :request do
         end
       end
 
-      response '200', 'No manifests found with bad appId' do
-        let(:appId) { 'invalid' }
+      response '200', 'No manifests found with bad app_id' do
+        let(:app_id) { 'invalid' }
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data.length).to eq 0
@@ -37,53 +48,46 @@ describe 'manifests', type: :request do
       end
 
       response '401', 'Invalid credentials' do
-        let(:appId) { user_app.name }
         let('access-token') { 'invalid-token' }
         run_test!
       end
-
     end
 
-    post('create manifest') do
-      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
-      produces 'application/json'
+    post 'create manifest' do
+      tags 'Manifests'
+      security [ { access_token: [], client: [], uid: [] } ]
       consumes 'application/json'
-      parameter name: "appId", in: :path, type: :string
-      parameter name: :manifest, in: :body, schema: {}
+      produces 'manifest/json'
 
-      response(401, 'unauthorized with bad appId') do
-        let(:appId) { 'invalid' }
-        let(:manifest) { {content: '{}'} }
+      parameter name: :manifest, in: :body, schema: manifest_schema
+
+      response(401, 'unauthorized with bad app_id') do
+        let(:app_id) { 'invalid' }
+        let(:manifest) { { content: '{}' } }
         run_test!
       end
 
-
       response(400, 'malformed without required fields') do
-        let(:appId) { user_app.name }
         let(:manifest) { {} }
         run_test!
       end
 
       response(201, 'valid with required fields') do
-        let(:appId) { user_app.name }
-        let(:manifest) { {content: '{}'} }
+        let(:manifest) { { content: '{}' } }
         run_test!
       end
-
-
     end
-
   end
 
   path '/manifests/{id}' do
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+    let(:id) { user_manifest.id }
 
     get('show manifest') do
-      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
+      security [ { access_token: [], client: [], uid: [] } ]
       produces 'application/json'
-      parameter name: 'id', in: :path, type: :string, description: 'id'
 
       response(200, 'successful') do
-        let(:id) { user_manifest.id }
         run_test!
       end
 
@@ -93,59 +97,29 @@ describe 'manifests', type: :request do
       end
 
       response(401, 'unsuccessful with bad auth') do
-        let(:id) { user_manifest.id }
         let('access-token') { 'invalid-token' }
         run_test!
       end
-  
-    end
-
-    patch('update manifest') do
-      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
-      produces 'application/json'
-      consumes 'application/json'
-      parameter name: 'id', in: :path, type: :string, description: 'id'
-      parameter name: :manifest, in: :body, schema: {}
-
-      response(200, 'successful') do
-        let(:id) { user_manifest.id }
-        let(:manifest) { {content: '{updated: true}'} }
-
-        run_test! do |response|
-          content = JSON.parse(response.body)['content']
-          expect(content).to eq '{updated: true}'
-        end
-      end
-
-      response(401, 'unsuccessful with bad auth') do
-        let(:id) { user_manifest.id }
-        let(:manifest) { {content: '{updated: true}'} }
-        let('access-token') { 'invalid-token' }
-        run_test!
-      end
-
     end
 
     put('update manifest') do
-      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
-      produces 'application/json'
+      security [ { access_token: [], client: [], uid: [] } ]
       consumes 'application/json'
-      parameter name: 'id', in: :path, type: :string, description: 'id'
-      parameter name: :manifest, in: :body, schema: {}
+      produces 'manifest/json'
+
+      parameter name: :manifest, in: :body, schema: manifest_schema
 
       response(200, 'successful') do
-        let(:id) { user_manifest.id }
-        let(:manifest) { {content: '{updated2: true}'} }
+        let(:manifest) { { content: '{ updated2: true }' } }
 
         run_test! do |response|
           content = JSON.parse(response.body)['content']
-          expect(content).to eq '{updated2: true}'
+          expect(content).to eq '{ updated2: true }'
         end
       end
 
       response(401, 'unsuccessful with bad auth') do
-        let(:id) { user_manifest.id }
-        let(:manifest) { {content: '{updated: true}'} }
+        let(:manifest) { { content: '{ updated: true }'} }
         let('access-token') { 'invalid-token' }
         run_test!
       end

--- a/spec/requests/manifests_spec.rb
+++ b/spec/requests/manifests_spec.rb
@@ -72,8 +72,13 @@ describe 'manifests', type: :request do
         run_test!
       end
 
-      response(201, 'valid with required fields') do
+      response(201, 'valid with content as string') do
         let(:manifest) { { content: '{}' } }
+        run_test!
+      end
+
+      response(201, 'valid with content as hash') do
+        let(:manifest) { { content: { app: 1234, definitions: [] } } }
         run_test!
       end
     end


### PR DESCRIPTION
**Before**
`Manifest.content` json data was stored in a stringified form that was somewhat inconvenient to work with

**After**
stringified data is migrated to jsonb/hash format
controller accepts strings or hashes for content to provide a parallel path forward

**Notes**
pairs with front-end PR:
- https://github.com/solid-adventure/trivial-ui/pull/144