### PR TITLE
migrate/manifest-content

### DIFF
--- a/db/migrate/20240829200814_manifest_content_to_json.rb
+++ b/db/migrate/20240829200814_manifest_content_to_json.rb
@@ -1,0 +1,31 @@
+class ManifestContentToJson < ActiveRecord::Migration[7.0]
+  def up
+    Manifest.all.each do |manifest|
+      return if manifest.content.is_a? Hash
+      manifest.update!(content: jsonify_content(manifest.id, manifest.content))
+    end
+  end
+
+  def down
+    Manifest.all.each do |manifest|
+      return if manifest.content.is_a? String
+      manifest.update!(content: stringify_content(manifest.id, manifest.content))
+    end
+  end
+
+  def jsonify_content(id, content)
+    return if content.blank?
+    JSON.parse(content)
+  rescue => e
+    puts "Could not transform Manifest #{id}, #{content}"
+    content
+  end
+
+  def stringify_content(id, content)
+    return if content.blank?
+    content.to_json
+  rescue => e
+    puts "Could not transform Manifest #{id}, #{content}"
+    content
+  end
+end


### PR DESCRIPTION
adds a data migration to convert manifest content from string format to jsonb format

**Notes**
must run after these are merged to maintain a parallel path:
- https://github.com/solid-adventure/trivial-api/pull/292
- https://github.com/solid-adventure/trivial-ui/pull/144