### PR TITLE
feature/register-items-filters-sum

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
   resources :register_items, only: [:index, :show, :create, :update] do
     collection do
       get 'columns'
+      get 'sum'
     end
   end
 


### PR DESCRIPTION
**Before**
No way of retrieving a sum for filtered sets of `RegisterItem` data

**After**
Created endpoint for retrieving a sum that also accepts search filtering parameters