### PR TITLE
enhance/register-items-sum

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -64,10 +64,13 @@ class RegisterItemsController < ApplicationController
   end
 
   def sum
-    sum_col = params[:col] || 'amount'
-    raise "invalid sum column: #{sum_col}" unless RegisterItem.columns_hash[sum_col]&.type == :decimal
-
-    render json: { sum: @register_items.sum(sum_col) }, status: :ok
+    col = params[:col] || 'amount'
+    validated_column = RegisterItem.columns_hash[col]
+    if validated_column && validated_column.type == :decimal
+      render json: { sum: @register_items.sum(validated_column.name) }, status: :ok
+    else
+      render json: { error: "invalid sum column: #{col}" }, status: :bad_request
+    end
   end
 
   private

--- a/spec/requests/register_items_spec.rb
+++ b/spec/requests/register_items_spec.rb
@@ -1,0 +1,66 @@
+
+require 'rails_helper'
+require 'swagger_helper'
+
+describe "Charts API", type: :request do
+  let(:user) { FactoryBot.create(:user, :logged_in) }
+  let(:client) { user.tokens.keys.first }
+  let('access-token') { user.tokens[client]['token_unhashed'] }
+  let(:uid) { user.uid }
+  let(:organization) { FactoryBot.create :organization, admin: user }
+  let(:other_register) { organization.owned_registers.first }
+  let(:current_register) { FactoryBot.create :register, owner: organization }
+
+  def self.sum_schema
+    {
+      type: :object,
+      properties: {
+        sum: { type: :number }
+      },
+      required: %w[sum]
+    }
+  end
+
+  before do
+    FactoryBot.create(:register_item, register: current_register, originated_at: Time.now - 2.weeks)
+    FactoryBot.create(:register_item, register: current_register, originated_at: Time.now - 1.week)
+    FactoryBot.create(:register_item, register: current_register, originated_at: Time.now)
+    FactoryBot.create(:register_item, register: other_register, originated_at: Time.now)
+  end
+
+  path '/register_items/sum' do
+    parameter name: 'register_id', in: :query, type: :integer, description: 'A specific register id', required: false
+    parameter name: 'col', in: :query, type: :integer, description: 'The column to sum on', required: false
+    parameter name: 'search', in: :query, type: :string, description: 'A hash of filters', required: false
+
+    get "Sum of RegisterItems" do
+      tags 'RegisterItems'
+      security [ { access_token: [], client: [], uid: [] } ]
+      produces  'register_item/json'
+
+      response '200', 'Get a sum of register_items, no filters' do
+        schema type: sum_schema
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['sum'].to_f).to eq(10.00)
+        end
+      end
+
+      response '200', 'Get a sum of register_items, no filters' do
+        schema type: sum_schema
+
+        let(:register_id) { current_register.id }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['sum'].to_f).to eq(7.50)
+        end
+      end
+
+      response '400', "injection attempt on sum column" do
+        let(:col) { 'DROP TABLE users' }
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Before**
raising an error created an unhandled exception resulting in a 500 response

**After**
We directly render a 400 response instead of raising an exception. This has better clarity for users of the API
Added tests to verify the end-point is working and not susceptible to injection.