### PR TITLE
audits api for organizations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,6 +22,10 @@ class Organization < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
+  def admin?(user)
+    org_roles.find_by(user: user)&.role == 'admin'
+  end
+
   private
     def create_default_register
       Register.create!(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   resources :users
 
-  resources :organizations do
+  resources :organizations, concerns: :auditable do
     member do
       delete 'delete_org_role'
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -21,4 +21,22 @@ describe Organization do
       expect(OrgRole.where(organization: organization, role: 'admin').count).to eq(1)
     end
   end
+
+  describe 'admin?' do
+    before do
+      @admin = FactoryBot.create :user
+      @organization = FactoryBot.create :organization, admin: @admin, members_count: 1
+      @member = @organization.org_roles.find_by(role: 'member').user
+      @nonmember = FactoryBot.create :user
+    end
+    it 'is true if user is an admin of the Organization' do
+      expect(@organization.admin?(@admin)).to be true
+    end
+    it 'is false if user is a member of the Organization' do
+      expect(@organization.admin?(@member)).to be false
+    end
+    it 'is falsey for non-members of the Organization' do
+      expect(@organization.admin?(@nonmember)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
**Before**
`Audits` API did not support `Organizations`

**After**
`Audits` API supports `Organizations`