### PR TITLE
enhance/activity_entry_index_efficiency

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -129,7 +129,8 @@ class ActivityEntriesController < ApplicationController
   def activity_for_index
     attrs = [:id, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :created_at]
     @activity ||= app_activity
-    @activity.select(attrs).limit(limit).order(id: :desc)
+    ids = @activity.pluck(:id)
+    ActivityEntry.select(attrs).where(id: ids).order(id: :desc).limit(limit)
   end
 
   def activity


### PR DESCRIPTION
**Before**
calling limit directly on the index query caused the query planner to become significantly less efficient

**After**
selecting for ids then searching with a limit on these ids should cause the query planner to use a more a efficient plan