### PR TITLE
split report into 2 date ranges and cache the older results

### DIFF
--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -1,5 +1,6 @@
 module Services
   class Report
+
     def item_count(args)
       simple_stat_lookup("count", args)
     end
@@ -12,9 +13,46 @@ module Services
       simple_stat_lookup("average", args)
     end
 
+    def cache_cutoff(timezone)
+      (Time.now - 2.days).beginning_of_day.in_time_zone(timezone)
+    end
+
+    def cache_key(stat, args)
+      "simple_stat_lookup/#{stat}_#{args.reject { |k, _| k == :user }.to_s}"
+    end
+
     private
 
+
+    # The main entry point for all report queries. This method
+    # will check if the end_at time is after the cache cutoff
+    # and if so, will combine the cached results with the live db results
     def simple_stat_lookup(stat, args)
+      timezone = validate_timezone!(args[:timezone]).freeze
+      start_at, end_at = validate_time_range!(args[:start_at], args[:end_at], timezone)
+      cutoff = cache_cutoff(timezone)
+
+      if start_at <= cutoff && end_at <= cutoff
+        return cached_simple_stat_lookup(stat, args)
+      elsif start_at <= cutoff && end_at > cutoff
+        cached_result = cached_simple_stat_lookup(stat, args.merge(end_at: cutoff.iso8601))
+        live_result = _simple_stat_lookup(stat, args.merge(start_at: cutoff.iso8601))
+        return combine_results(cached_result, live_result)
+      elsif start_at > cutoff && end_at > cutoff
+        return _simple_stat_lookup(stat, args)
+      else
+        # This case should never happen if the input is validated correctly
+        raise ArgumentError, "Invalid time range"
+      end
+    end
+
+    def cached_simple_stat_lookup(stat, args)
+      Rails.cache.fetch(cache_key(stat, args), expires_in: 1.day) do
+        _simple_stat_lookup(stat, args)
+      end
+    end
+
+    def _simple_stat_lookup(stat, args)
       return unless stat.in? %w(count sum average)
       timezone = validate_timezone!(args[:timezone]).freeze
       start_at, end_at = validate_time_range!(args[:start_at], args[:end_at], timezone)
@@ -148,5 +186,31 @@ module Services
       raise ArgumentError, 'timezone mismatched from time range timezones' if timezone.utc_offset != time.utc_offset
       time
     end
+
+    def combine_results(cached_result, live_result)
+      raise "Invalid cached result" unless cached_result.is_a?(Hash)
+      raise "Invalid live result" unless live_result.is_a?(Hash)
+
+      combined = { title: cached_result[:title] }
+      cached_counts = cached_result[:count] || []
+      live_counts = live_result[:count] || []
+
+      all_groups = (cached_counts + live_counts).map { |item| [item[:period], item[:group]] }.uniq
+
+      # Create lookup hashes for faster access
+      cached_lookup = cached_counts.each_with_object({}) { |item, hash| hash[[item[:period], item[:group]]] = item[:value] }
+      live_lookup = live_counts.each_with_object({}) { |item, hash| hash[[item[:period], item[:group]]] = item[:value] }
+
+      combined[:count] = all_groups.map do |period, group|
+        {
+          period: period,
+          group: group,
+          value: (cached_lookup[[period, group]] || 0) + (live_lookup[[period, group]] || 0)
+        }
+      end
+
+      combined
+    end
+
   end
 end

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -43,6 +43,130 @@ RSpec.describe Services::Report do
       expect(results[:count].first[:value]).to eq(2)
     end
 
+    it 'only uses the cache if the entire period is before the cache cutoff' do
+      expect(report).to receive(:cached_simple_stat_lookup).once
+      report.send(:simple_stat_lookup, 'count', args)
+    end
+
+    it 'only uses the live query if the entire period is after the cache cutoff' do
+      args[:start_at] = (Time.now - 1.day).iso8601
+      args[:end_at] = Time.now.iso8601
+      expect(report).to receive(:_simple_stat_lookup).once
+      report.send(:simple_stat_lookup, 'count', args)
+    end
+
+    it 'splits date range into a live and a cached query' do
+      args[:timezone] = 'Etc/GMT+4'
+      args[:end_at] = Time.now.in_time_zone(args[:timezone]).iso8601
+
+      start_time = args[:start_at]
+      end_time = args[:end_at]
+      cutoff = report.cache_cutoff(args[:timezone]).iso8601
+
+      expect(report).to receive(:cached_simple_stat_lookup).once do |stat, options|
+        expect(stat).to eq('count')
+        expect(options[:start_at]).to eq(start_time)
+        expect(options[:end_at]).to eq(cutoff)
+      end
+
+      expect(report).to receive(:_simple_stat_lookup).once do |stat, options|
+        expect(stat).to eq('count')
+        expect(options[:start_at]).to eq(cutoff)
+        expect(options[:end_at]).to eq(end_time)
+      end
+
+      allow(report).to receive(:combine_results).and_return({})
+      results = report.send(:simple_stat_lookup, 'count', args)
+    end
+
+    it 'makes use of the cache' do
+      expect(Rails.cache).to receive(:fetch).with(
+        report.send(:cache_key, 'count', args),
+         {expires_in: 1.day}
+      ).and_yield
+      report.send(:cached_simple_stat_lookup, 'count', args)
+    end
+
+    it 'combines the results of a live and a cached query' do
+      args[:end_at] = Time.now.iso8601
+      initialResult = report.send(:simple_stat_lookup, 'count', args)
+      expect(initialResult[:count].first[:value]).to eq(2)
+      FactoryBot.create(
+        :register_item,
+        register:,
+        originated_at: Time.now - 1.hour
+      )
+      updatedResult = report.send(:simple_stat_lookup, 'count', args)
+      expect(updatedResult[:count].first[:value]).to eq(3)
+    end
+
+    it 'uses a compatible timezone when splitting the queries' do
+      timezone = report.send(:validate_timezone!, 'Etc/GMT+5')
+      start_at = (Time.now - 1.week).in_time_zone(timezone).iso8601
+      cutoff = report.cache_cutoff(timezone).iso8601
+      expect(report.send(:validate_time_range!, start_at, cutoff, timezone)).to eq([start_at, cutoff])
+    end
+
+    it 'combines results when live and cached query have returned the same groups' do
+      cached_result = {
+        title: 'Count by Entity Type',
+        count: [
+          { period: 'All', group: 'Order', value: 2 }
+        ]
+      }
+      live_result = {
+        title: 'Count by Entity Type',
+        count: [
+          { period: 'All', group: 'Order', value: 3 }
+        ]
+      }
+      result = report.send(:combine_results, cached_result, live_result)
+      expect(result[:title]).to eq('Count by Entity Type')
+      expect(result[:count].length).to eq(1)
+      expect(result[:count][0][:value]).to eq(5)
+    end
+
+    it 'combines results when live and cached query have returned different periods' do
+      cached_result = {:title=>"Count by Month", :count=>[{:period=>"Jan 2023", :group=>"All", :value=>0}, {:period=>"Feb 2023", :group=>"All", :value=>1} ]}
+      live_result =   {:title=>"Count by Month", :count=>[{:period=>"Mar 2023", :group=>"All", :value=>2}, {:period=>"Apr 2023", :group=>"All", :value=>3} ]}
+      result = report.send(:combine_results, cached_result, live_result)
+      result[:count].each_with_index do |group, i|
+        expect(group[:value]).to eq(i)
+      end
+    end
+
+    it 'combines results when live and cached query have returned overlapping groups' do
+      cached_result = {:title=>"Count by Month", :count=>[{:period=>"Jan 2023", :group=>"All", :value=>0}, {:period=>"Feb 2023", :group=>"All", :value=>1} ]}
+      live_result =   {:title=>"Count by Month", :count=>[{:period=>"Feb 2023", :group=>"All", :value=>2} ]}
+      result = report.send(:combine_results, cached_result, live_result)
+      expect(result[:count][0][:value]).to eq(0) # Jan 2023, 0
+      expect(result[:count][1][:value]).to eq(3) # Feb 2023, 1 + 2
+    end
+
+    it 'combines results when live and cached query have multidimensional groups' do
+      cached_result = {:title=>"Count by Entity Type, Entity Id", :count=>[{:period=>"All", :group=>["Order", "1"], :value=>0}, {:period=>"All", :group=>["Order", "2"], :value=>1}]}
+      live_result =   {:title=>"Count by Entity Type, Entity Id", :count=>[{:period=>"All", :group=>["Order", "1"], :value=>2}, {:period=>"All", :group=>["Order", "3"], :value=>3}]}
+      result = report.send(:combine_results, cached_result, live_result)
+      expect(result[:count][0][:value]).to eq(2) # Order 1, 0 + 2
+      expect(result[:count][1][:value]).to eq(1) # Order 2, 1
+      expect(result[:count][2][:value]).to eq(3) # Order 3, 3
+    end
+
+     it 'combines results when live and cached query have multidimensional groups and different periods' do
+      cached_result = {:title=>"Count by Quarter and Entity Type, Entity Id", :count=>[{:period=>"Q1 2023", :group=>["Order", "2"], :value=>0}, {:period=>"Q2 2023", :group=>["Order", "2"], :value=>1}]}
+      live_result =   {:title=>"Count by Quarter and Entity Type, Entity Id", :count=>[{:period=>"Q3 2023", :group=>["Order", "3"], :value=>2}, {:period=>"Q3 2023", :group=>["Order", "4"], :value=>4}]}
+      result = report.send(:combine_results, cached_result, live_result)
+      expect(result[:count][0][:value]).to eq(0) # Q1 2023, Order 2, 0
+      expect(result[:count][1][:value]).to eq(1) # Q2 2023, Order 2, 1
+      expect(result[:count][2][:value]).to eq(2) # Q3 2023, Order 3, 2
+      expect(result[:count][3][:value]).to eq(4) # Q3 2023, Order 4, 4
+    end
+
+    it 'produces a valid cache key' do
+      key = report.send(:cache_key, 'count', args)
+      expect(key).to eq("simple_stat_lookup/count_{:start_at=>\"2023-01-01T00:00:00-04:00\", :end_at=>\"2023-12-31T23:59:59-04:00\", :register_id=>#{args[:register_id]}}")
+    end
+
     it 'only includes specified dates' do
       args[:end_at] = (start_at + 2.months - 1.second).iso8601 # Feb 28, 2023 11:59:59PM EDT
       results = report.send(:simple_stat_lookup, 'count', args)


### PR DESCRIPTION
**Before**
Expensive report queries always hit the database, causing slow API responses & timeouts

**After**
A report's date range is split into two halves. The 1/2 that does not includes the last 2 days has its response cached for 24 hours. The 1/2 for the last 2 days always hits the live database, and the results are combined.


Note: These API calls will still be slow the first time they are called in the 24 hours; if this strategy is otherwise working, the next step would be to identify the stats we want to warm up on server start + daily. Because that would entail a fair amount of date coordination with`trivial-ui`, and because it's primarily the `charts` rendering that makes the calls to `/reports`, we may want to add semantic values like "Last 7 Days", "Last Month", etc., to charts, and keep the date manipulation together in the API. 

With that, it would be straightforward to warmup the exact reports the charts will call for before users do.