### PR TITLE
do not raise on non-matching tz offsets dst issues

### DIFF
--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -183,7 +183,6 @@ module Services
     def validate_time!(time_string, timezone)
       time = Time.iso8601(time_string)
       return time unless timezone
-      raise ArgumentError, 'timezone mismatched from time range timezones' if timezone.utc_offset != time.utc_offset
       time
     end
 

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -359,13 +359,6 @@ RSpec.describe Services::Report do
       end.to raise_error(ArgumentError)
     end
 
-    it 'raises an error if start_at or end_at timezones mismatch from timezone' do
-      args[:timezone] = 'Etc/GMT+5' # EST, start_at and end_at are EDT
-      expect do
-        report.send(:simple_stat_lookup, 'count', args)
-      end.to raise_error(ArgumentError)
-    end
-
     it 'raises an error when an invalid group_by is provided' do
       args[:group_by] = ['register_id']
       expect do


### PR DESCRIPTION
**Before**
Sending a named timezone short name like, "America/New_York" with a range spanning across daylight savings raises an error, `'timezone mismatched from time range timezones`.

**After**
Report queries with a range spanning across daylight savings work as expected with a named range.

**Notes**
Basically, we can't rely on ruby's `timezone.utc_offset` because of daylight savings.

```ruby
# In January, we have a 5 hour offset, all good.
validate_time! 2024-01-01T00:00:00-05:00, timezone: (GMT-05:00) America/New_York
time.utc_offset: -18000
timezone.utc_offset: -18000

# In October, we have a 4 hour offset. The timezone object doesn't factor for it, still calling the America/New_York a 5 hour offset. No bueno.
validate_time! 2024-10-02T23:59:59-04:00, timezone: (GMT-05:00) America/New_York
time.utc_offset: -14400 # this has correctly changed to 14400
timezone.utc_offset: -18000 # this has not

# The Postgres implementation is correct, which is where the offset is applied.
# 5 hour offset  in January makes it through to the query
originated_at >= '2024-01-01 05:00:00'

# as does the 4 hour offset
originated_at <= '2024-10-03 03:59:59'
```