### PR TITLE
fix/manifest-copy

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -21,17 +21,11 @@ class Manifest < ApplicationRecord
         new_manifest.app_id = new_app.name
         new_manifest.owner = new_app.owner
         new_manifest.internal_app_id = new_app.id
-        new_manifest.set_content_app_id
+        new_manifest.content["app_id"] = new_manifest.app_id
         # Pushing this responsibility to CredentialSet, which would be able to display an error if the new user doesn't have access to the creds 
         # new_manifest.remove_config
         new_manifest.save!
         return new_manifest
-    end
-
-    def set_content_app_id
-        content = JSON.parse(self.content)
-        content["app_id"] = self.app_id
-        self.content = content.to_json
     end
 
     def remove_config

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -21,6 +21,9 @@ class Manifest < ApplicationRecord
         new_manifest.app_id = new_app.name
         new_manifest.owner = new_app.owner
         new_manifest.internal_app_id = new_app.id
+        if new_manifest.content.is_a? String
+            new_manifest.content = JSON.parse(new_manifest.content)
+        end
         new_manifest.content["app_id"] = new_manifest.app_id
         # Pushing this responsibility to CredentialSet, which would be able to display an error if the new user doesn't have access to the creds 
         # new_manifest.remove_config

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -4,7 +4,7 @@ class ManifestTest < ActiveSupport::TestCase
     def setup
         @manifest = Manifest.new
         @manifest.app_id = 'BrownShirt'
-        @manifest.content = '{"x":1}'
+        @manifest.content = { "x": 1 }
         @manifest.owner = User.create(name: 'bilbo', email: 'test@gmail.com', password: '12345678')
         @manifest.app = App.create(owner: @manifest.owner, name: 'BrownShirt')
         @manifest.save!
@@ -44,5 +44,6 @@ class ManifestTest < ActiveSupport::TestCase
         new_manifest = @manifest.copy_to_app!(new_app)
         assert_equal new_manifest.owner, @user2
         assert_equal new_manifest.app, new_app
+        assert_equal new_manifest.content['app_id'], new_app.name
     end
 end

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -36,12 +36,6 @@ class ManifestTest < ActiveSupport::TestCase
         assert_equal @manifest.errors[:owner], ["must exist"]
     end
 
-    test 'content app id updates to app_id' do
-        @manifest.set_content_app_id
-        content = JSON.parse(@manifest.content)
-        assert_equal content["app_id"], "BrownShirt"
-    end
-
     test 'copy_to_app! updates app and user' do
         new_app = App.new(descriptive_name: "Hold Steady")
         new_app.owner = @user2


### PR DESCRIPTION
**Before**
when copying an `App` the new `Manifest` copy was treated as having `content` with a `String`-type value

**After**
Manifest `content` is treated as a `Hash`-type when copying