### PR TITLE
feature/procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rails runner "CacheWarmUpJob.perform_now(cache_name: 'app_activity_stats')"


### PR DESCRIPTION
**Before**
no `Procfile` to run with Heroku

**After**
added `Procfile` to introduce deployment release phase behavior

**Note**
Heroku runs the following default behavior as a part of the web phase:
`bundle exec rails server -p $PORT -e $RAILS_ENV`
This behavior is only over written when introducing `web: ` commands to the Procfile