### PR TITLE
enhance/cache_warmup_job

### DIFF
--- a/app/jobs/cache_warm_up_job.rb
+++ b/app/jobs/cache_warm_up_job.rb
@@ -3,31 +3,33 @@ class CacheWarmUpJob < ApplicationJob
   queue_as :default
 
   def perform(cache_name:, options: {})
+    puts("CacheWarmUpJob started for cache: #{cache_name}")
     case cache_name
     when 'app_activity_stats'
       warm_up_app_activity_stats(**options)
     else
-      Rails.logger.info("Invalid cache_name: #{cache_name}. Exiting.")
+      puts("CacheWarmUpJob invalid cache_name: #{cache_name}. Exiting.")
       return
     end
 
-    Rails.logger.info("Cache warm up successful. Exiting.")
+    puts("Cache warm up successful. Exiting.")
   rescue Timeout::Error
-    Rails.logger.error("CacheWarmupJob timed out after 2 hours, cache: #{cache}")
+    puts("CacheWarmUpJob timed out after 2 hours, cache: #{cache}")
   rescue => e
-    Rails.logger.error("CacheWarmUpJob failed: #{e.message}")
+    puts("CacheWarmUpJob failed: #{e.message}")
   end
 
   private
 
-  def warm_up_app_activity_stats(app_ids: App.kept.pluck(:id), date_cutoff: Date.today - 7.days, sleep: rand(0..900))
+  def warm_up_app_activity_stats(app_ids: App.kept.pluck(:id), date_cutoff: Date.today - 7.days, delay_duration: rand(0..900))
     raise 'app_ids must be an array of integers' unless app_ids.is_a? Array
     raise 'date_cutoff must be a Date type' unless date_cutoff.is_a? Date
 
-    sleep(sleep) # sleep to decrease DB collisions on multiple Rails instances
+    puts("CacheWarmUpJob Warm up app_activity_stats will start after #{delay_duration} seconds") if delay_duration > 0
+    sleep(delay_duration) # sleep to decrease DB collisions on multiple Rails instances
 
     Timeout.timeout(2.hours) do
-      Rails.logger.info("Warming up app_activity_stats cache with #{app_ids.size} apps and cutoff date #{date_cutoff}")
+      puts("CacheWarmUpJob Warming up app_activity_stats cache with #{app_ids.size} apps and cutoff date #{date_cutoff}")
       App.cache_stats_for!(app_ids:, date_cutoff:)
     end
   end

--- a/app/jobs/cache_warm_up_job.rb
+++ b/app/jobs/cache_warm_up_job.rb
@@ -3,7 +3,6 @@ class CacheWarmUpJob < ApplicationJob
   queue_as :default
 
   def perform(cache_name:, options: {})
-    puts("CacheWarmUpJob started for cache: #{cache_name}")
     case cache_name
     when 'app_activity_stats'
       warm_up_app_activity_stats(**options)
@@ -12,7 +11,7 @@ class CacheWarmUpJob < ApplicationJob
       return
     end
 
-    puts("Cache warm up successful. Exiting.")
+    puts("CacheWarmUpJob successful. Exiting.")
   rescue Timeout::Error
     puts("CacheWarmUpJob timed out after 2 hours, cache: #{cache}")
   rescue => e
@@ -22,8 +21,8 @@ class CacheWarmUpJob < ApplicationJob
   private
 
   def warm_up_app_activity_stats(app_ids: App.kept.pluck(:id), date_cutoff: Date.today - 7.days, delay_duration: rand(0..900))
-    raise 'app_ids must be an array of integers' unless app_ids.is_a? Array
-    raise 'date_cutoff must be a Date type' unless date_cutoff.is_a? Date
+    raise 'app_ids for app_activity_stats must be an array of integers' unless app_ids.is_a? Array
+    raise 'date_cutoff for app_activity_stats must be a Date type' unless date_cutoff.is_a? Date
 
     puts("CacheWarmUpJob Warm up app_activity_stats will start after #{delay_duration} seconds") if delay_duration > 0
     sleep(delay_duration) # sleep to decrease DB collisions on multiple Rails instances

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,6 @@ env :PATH, ENV['PATH']
 set :output, "#{path}/log/cron.log"
 set :environment, ENV['RAILS_ENV']
 
-every 1.day, at: '12:01 am' do
-  runner "CacheWarmupJob.perform_now(cache_name: 'app_activity_stats', sleep: 0)"
+every 1.day, at: '2:30 am' do
+  runner "CacheWarmUpJob.perform_now(cache_name: 'app_activity_stats')"
 end

--- a/db/migrate/20240716212256_create_dashboards.rb
+++ b/db/migrate/20240716212256_create_dashboards.rb
@@ -18,6 +18,6 @@ class CreateDashboards < ActiveRecord::Migration[7.0]
         }
       )
     end
-    Dashboard.insert_all(default_dashboards)
+    Dashboard.insert_all(default_dashboards) if default_dashboards.any?
   end
 end

--- a/spec/jobs/cache_warm_up_job_spec.rb
+++ b/spec/jobs/cache_warm_up_job_spec.rb
@@ -39,14 +39,16 @@ RSpec.describe CacheWarmUpJob, type: :job do
 
     it 'logs an error if app_ids is not an array' do
       options = { app_ids: "not_an_array", date_cutoff: }
-      expect(Rails.logger).to receive(:error).with("CacheWarmUpJob failed: app_ids must be an array of integers")
-      instance.perform(cache_name:, options:)
+      expect {
+        instance.perform(cache_name:, options:)
+      }.to output("CacheWarmUpJob failed: app_ids for app_activity_stats must be an array of integers\n").to_stdout
     end
 
     it 'logs an error if date_cutoff is not a Date' do
       options = { app_ids: , date_cutoff: 'not_a_date' }
-      expect(Rails.logger).to receive(:error).with("CacheWarmUpJob failed: date_cutoff must be a Date type")
-      instance.perform(cache_name:, options:)
+      expect {
+        instance.perform(cache_name:, options:)
+      }.to output("CacheWarmUpJob failed: date_cutoff for app_activity_stats must be a Date type\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
Minor updates to output and variables for clarity:
- use `delay_duration` instead of `sleep` for sleep time
- preface log outputs with `CacheWarmUpJob`
- use `puts` instead of `Rails.logger` for partially stood up environments
- add safety check to `Dashboards` migration