### PR TITLE
Enhance/audits payload2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem "scenic", "~> 1.8"
+gem 'diffy'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.1)
     diff-lcs (1.5.0)
+    diffy (3.4.2)
     discard (1.2.1)
       activerecord (>= 4.2, < 8)
     dotenv (2.8.1)
@@ -323,6 +324,7 @@ DEPENDENCIES
   cancancan
   devise_invitable (~> 2.0)
   devise_token_auth
+  diffy
   discard (~> 1.2)
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,12 +4,13 @@ class AuditsController < ApplicationController
   before_action :set_pagination, only: %i[index]
 
   def index
-    @audits = @auditable.own_and_associated_audits
+    @audits = @auditable.own_and_associated_audits.includes(:user).order(created_at: :desc)
     paginate_audits
+    format_changes
     response = {
       current_page: @page,
       total_pages: @total_pages,
-      audits: @audits.as_json(except: %i[user_type username audited_changes comment request_uuid])
+      audits: @audits.as_json(except: %i[user_type username comment request_uuid])
     }
 
     render json: response, status: :ok
@@ -25,6 +26,8 @@ class AuditsController < ApplicationController
   def load_and_authorize_auditable
     resource, id = request.path.split('/')[1,2]
     @auditable = resource.singularize.classify.constantize.find(id)
+
+    puts "@auditable: #{@auditable.inspect}"
 
     raise CanCan::AccessDenied unless @auditable.admin?(current_user)
   end
@@ -49,4 +52,59 @@ class AuditsController < ApplicationController
     offset = (@page - 1) * @per_page
     @audits = @audits.limit(@per_page).offset(offset)
   end
+
+  def pretty_json_diff?(auditable_type, key)
+    auditable_type == 'Manifest' && key == 'content' ||
+    auditable_type == 'Register' && key == 'meta'
+  end
+
+  def reference_name(audit)
+    audit.associated.respond_to?(:descriptive_name) && audit.associated&.descriptive_name ||
+    audit.auditable.respond_to?(:descriptive_name) && audit.auditable&.descriptive_name ||
+    audit.auditable.respond_to?(:name) && audit.auditable&.name ||
+    'Not provided'
+  end
+
+  def format_changes
+    @audits = @audits.map do |audit|
+
+      {
+        id: audit.id,
+        user_id: audit.user&.id,
+        user_name: audit.user&.name || 'Not provided',
+        user_email: audit.user&.email || 'Not provided',
+        action: audit.action,
+        reference_type: audit.associated_type || audit.auditable_type,
+        reference_id: audit.associated_id || audit.auditable_id,
+        reference_name: reference_name(audit),
+        created_at: audit.created_at,
+        audited_changes: audit.audited_changes.map do |key, value|
+
+          if pretty_json_diff? audit.auditable_type, key
+            {
+              attribute: key,
+              patch: Manifest.json_patch(*value),
+              old_value: value.is_a?(Array) ? value[0] : nil,
+              new_value: value.is_a?(Array) ? value[1] : value
+            }
+          elsif audit.auditable_type == 'User' && key == 'tokens'
+            {
+              attribute: key,
+              patch: "Log In",
+              old_value: value.is_a?(Array) ? value[0] : nil,
+              new_value: value.is_a?(Array) ? value[1] : value
+            }
+          else
+            {
+              attribute: key,
+              patch: "- #{key}: #{value[0]}\n+ #{key}: #{value[1]}",
+              old_value: value.is_a?(Array) ? value[0] : nil,
+              new_value: value.is_a?(Array) ? value[1] : value
+            }
+          end
+        end.flatten
+      }
+    end
+  end
+
 end

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -81,6 +81,20 @@ class AuditsController < ApplicationController
         audited_changes: audit.audited_changes.map do |key, value|
 
           if pretty_json_diff? audit.auditable_type, key
+
+
+            # TODO: This "Invalid JSON" message happens when you copy an app, because the content changes at the same time as
+            #       the other attributes. We should separate the content diff from the
+            #       other attribute changes
+
+            # Invalid JSON
+            # owner_id: 18
+            # owner_type: Organization
+            # internal_app_id: 1476
+            # The rescue is silencing this:
+            # ArgumentError (wrong number of arguments (given 11, expected 0..2)):
+            # app/models/manifest.rb:55:in `json_patch'
+
             begin
               {
                 attribute: key,

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -90,7 +90,7 @@ class AuditsController < ApplicationController
           elsif audit.auditable_type == 'User' && key == 'tokens'
             {
               attribute: key,
-              patch: "Log In / Out"
+              patch: "Log In / Out",
               old_value: value.is_a?(Array) ? value[0] : nil,
               new_value: value.is_a?(Array) ? value[1] : value
             }

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -88,7 +88,7 @@ class AuditsController < ApplicationController
                 old_value: value.is_a?(Array) ? value[0] : nil,
                 new_value: value.is_a?(Array) ? value[1] : value
               }
-            rescue JSON::ParserError
+            rescue
               Rails.logger.error "Invalid JSON in audit #{audit.id}"
               {
                 attribute: key,

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -90,18 +90,26 @@ class AuditsController < ApplicationController
           elsif audit.auditable_type == 'User' && key == 'tokens'
             {
               attribute: key,
-              patch: "Log In",
+              patch: "Log In / Out"
               old_value: value.is_a?(Array) ? value[0] : nil,
               new_value: value.is_a?(Array) ? value[1] : value
             }
-          else
+          elsif value.is_a?(Array)
             {
               attribute: key,
               patch: "- #{key}: #{value[0]}\n+ #{key}: #{value[1]}",
               old_value: value.is_a?(Array) ? value[0] : nil,
               new_value: value.is_a?(Array) ? value[1] : value
             }
+          else
+            {
+              attribute: key,
+              patch: "#{key}: #{value}",
+              old_value: value.is_a?(Array) ? value[0] : nil,
+              new_value: value.is_a?(Array) ? value[1] : value
+            }
           end
+
         end.flatten
       }
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -26,6 +26,30 @@ class Organization < ApplicationRecord
     org_roles.find_by(user: user)&.role == 'admin'
   end
 
+def own_and_associated_audits
+    Audited::Audit.where(<<-SQL,
+      (auditable_type = ? AND auditable_id = ?) OR
+      (associated_type = ? AND associated_id = ?) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?)) OR
+      (auditable_type = ? AND auditable_id IN (?))
+    SQL
+      'Organization', id,
+      'Organization', id,
+      'App', owned_apps.pluck(:id),
+      'Manifest', owned_manifests.pluck(:id),
+      'ManifestDraft', owned_manifest_drafts.pluck(:id),
+      'CredentialSet', owned_credential_sets.pluck(:id),
+      'Register', owned_registers.pluck(:id),
+      'Dashboard', owned_dashboards.pluck(:id),
+      'User', users.pluck(:id)
+    )
+  end
+
   private
     def create_default_register
       Register.create!(


### PR DESCRIPTION
@drowninginflowers 

Through the course of making this spike branch, I can see I put each of the major pieces in non-optimal places:
- [ ] the formatter in audits_controller should be a serializer
- [ ] the patch calculate in Manifest.rb works for any JSON; probably better on Audit.rb
- [ ] gathering org-wide audits in `own_and_associated_audits`. The logic here is accomplishing what we want, but probably not the cleanest way to do it. The tables it's bringing in are very small, so before we switch to adding an owner_type and owner_id columns, let's confirm it doesn't "just work" with a tidier version of the lookup approach used here.


Additionally, we need some search/export abilities to match register_items:
- [ ] app_id
- [ ] user_id
- [ ] created_at w/date ranges.
- [ ] streaming csv export option

Lastly:
- [ ] tests