### PR TITLE
Feature/multi register item create

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -35,20 +35,18 @@ class RegisterItemsController < ApplicationController
 
   # POST /register_items
   def create
-    @register_item = RegisterItem.new(register_item_params)
-    @register_item.owner = @register.owner
-    authorize! :create, @register_item
-    if @register_item.save
-      render json: @register_item, adapter: :attributes, status: :created
-    else
-      render json: @register_item.errors, status: :unprocessable_entity
-    end
+    @register_items = create_register_items
+    render json: @register_items, adapter: :attributes, status: :created
+  rescue CanCan::AccessDenied
+    render json: { error: 'Not authorized' }, status: :forbidden
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.message }, status: :unprocessable_entity
   end
 
   # PUT /register_items/1
   def update
     authorize! :update, @register_item
-    if @register_item.update(register_item_params)
+    if @register_item.update(register_item_params(@register))
       render json: @register_item, adapter: :attributes
     else
       render json: @register_item.errors, status: :unprocessable_entity
@@ -131,14 +129,51 @@ class RegisterItemsController < ApplicationController
     filter_register_items
   end
 
-  def register_item_params
-    permitted_params = params.permit(:unique_key, :description, :register_id, :amount, :units, :originated_at)
-    if @register
-      @register.meta.each do |column, label|
-        permitted_params[column] = params[label] if params[label]
+  def register_item_params(item_params = params, register)
+    permitted_params = item_params.permit(
+      :unique_key,
+      :description,
+      :register_id,
+      :amount,
+      :units,
+      :originated_at
+    )
+    if register
+      register.meta.each do |column, label|
+        permitted_params[column] = item_params[label] if item_params&.[](label)
       end
     end
     permitted_params
+  end
+
+  def create_register_items
+    ActiveRecord::Base.transaction do
+      params[:register_items].is_a?(Array) ? create_multiple_items : create_single_item
+    end
+  end
+
+  def create_multiple_items
+    register_ids = params[:register_items].map { |item| item[:register_id] }.uniq
+    registers = Register.where(id: register_ids).index_by(&:id)
+
+    params[:register_items].map do |item_params|
+      register = registers[item_params[:register_id].to_i]
+      raise ActiveRecord::RecordNotFound, "Register not found for item #{item_params[:unique_key]}" unless register
+
+      create_item(register_item_params(item_params, register), register)
+    end
+  end
+
+  def create_single_item
+    create_item(register_item_params(params, @register), @register)
+  end
+
+  def create_item(item_params, register)
+    item = RegisterItem.new(item_params)
+    item.owner = register.owner
+    authorize! :create, item
+    item.save!
+    item
   end
 
   MAX_CSV_ROWS = 500000

--- a/test/controllers/register_items_controller_test.rb
+++ b/test/controllers/register_items_controller_test.rb
@@ -60,35 +60,7 @@ class RegisterItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     error_response = JSON.parse(response.body)
-    assert_equal error_response.keys, ["unique_key"]
-  end
-
-  test "should handle meta params when creating register item" do
-    # Setup register with numbered meta columns
-    @register.update(meta: {
-      "meta0" => "channel",
-      "meta1" => "custom_thing"
-    })
-
-    assert_difference('RegisterItem.count') do
-      post register_items_url,
-        params: {
-          unique_key: Time.now.to_i,
-          description: "Test Item",
-          register_id: @register.id,
-          units: 'USD',
-          amount: 100,
-          channel: "Online",           # This maps to meta0
-          custom_thing: "Special",   # This maps to meta1
-        },
-        headers: @auth_headers,
-        as: :json
-    end
-
-    assert_response :success
-    response_item = JSON.parse(response.body)
-    assert_equal "Online", response_item["channel"]
-    assert_equal "Special", response_item["custom_thing"]
+    assert_equal JSON.parse(response.body)["error"], "Validation failed: Unique key has already been taken"
   end
 
   test "should create register item with correct meta attributes" do
@@ -107,6 +79,181 @@ class RegisterItemsControllerTest < ActionDispatch::IntegrationTest
     meta_array.each do |col|
       assert_nil register_item[col]
     end
+  end
+
+  test "should reject creation when user is not authorized" do
+    # Setup an unauthorized user's headers
+    unauthorized_headers = { 'Authorization' => 'Bearer unauthorized_token' }
+
+    post register_items_url,
+      params: {
+        unique_key: "ABC123",
+        description: "Test Item",
+        register_id: @register.id
+      },
+      headers: unauthorized_headers,
+      as: :json
+
+    assert_response :unauthorized
+    error_response = JSON.parse(response.body)
+  end
+
+  test "should reject creation when user logged in does not have access to register" do
+    post register_items_url,
+      params: {
+        unique_key: "ABC123",
+        description: "Test Item",
+        register_id: 3, # register_id is not associated with the user
+        units: 'USD',
+        amount: 100
+      },
+      headers: @auth_headers,
+      as: :json
+
+    assert_response :forbidden
+    error_response = JSON.parse(response.body)
+    assert_equal error_response["error"], "Not authorized"
+  end
+
+  test "should create multiple register items with correct ownership" do
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        originated_at: Time.current
+      },
+      {
+        unique_key: "DEF456",
+        description: "Test Item 2",
+        register_id: @register.id,
+        amount: 200,
+        units: 'USD',
+        originated_at: Time.current
+      }
+    ]
+
+    assert_difference('RegisterItem.count', 2) do
+      post register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+
+    assert_response :created
+    response_items = JSON.parse(response.body)
+    assert_equal 2, response_items.length
+
+    RegisterItem.where(unique_key: ["ABC123", "DEF456"]).each do |item|
+      assert_equal @register.owner_id, item.owner_id
+      assert_equal "Organization", item.owner_type
+    end
+  end
+
+  test "should handle meta params and ownership in bulk creation" do
+    @register.update!(meta: {
+      "meta0" => "channel",
+      "meta1" => "custom_thing"
+    })
+
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        channel: "Online",
+        custom_thing: "Special"
+      },
+      {
+        unique_key: "DEF456",
+        description: "Test Item 2",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        channel: "Retail",
+        custom_thing: "Regular"
+      }
+    ]
+
+    assert_difference('RegisterItem.count', 2) do
+      post register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+
+    assert_response :created
+    response_items = JSON.parse(response.body)
+
+    RegisterItem.where(unique_key: ["ABC123", "DEF456"]).each do |item|
+      assert_equal @register.owner_id, item.owner_id
+      assert_equal "Organization", item.owner_type
+      assert item.meta0.in?(["Online", "Retail"])
+      assert item.meta1.in?(["Special", "Regular"])
+    end
+  end
+
+  test "should rollback ownership and meta if any item is invalid" do
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD'
+      },
+      {
+        unique_key: "ABC123",  # invalid
+        description: "Test Item 2",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD'
+      }
+    ]
+
+    assert_no_difference(['RegisterItem.count']) do
+      post register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+    assert_response :unprocessable_entity
+    assert_equal JSON.parse(response.body)["error"], "Validation failed: Unique key has already been taken"
+    assert_not RegisterItem.exists?(unique_key: "ABC123")
+  end
+
+  test "should rollback if any item has invalid ownership" do
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD'
+      },
+      {
+        unique_key: "DEF456",
+        description: "Test Item 2",
+        register_id: 3, # invalid
+        amount: 100,
+        units: 'USD'
+      }
+    ]
+
+    assert_no_difference(['RegisterItem.count']) do
+      post register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+    assert_response :forbidden
+    assert_equal JSON.parse(response.body)["error"], "Not authorized"
+    assert_not RegisterItem.exists?(unique_key: "ABC123")
+    assert_not RegisterItem.exists?(unique_key: "DEF456")
   end
 
   test 'correctly aliases meta-columns for items from differing registers but overlapping aliases' do

--- a/test/fixtures/registers.yml
+++ b/test/fixtures/registers.yml
@@ -27,3 +27,15 @@ two:
   }
   owner_type: Organization
   owner_id: 1
+
+three:
+  id: 3
+  name: Register 3
+  units: USD
+  meta: {
+    "meta1": "income_account",
+    "meta2": "channel",
+    "meta3": "warehouse",
+  }
+  owner_type: Organization
+  owner_id: 2


### PR DESCRIPTION
**Before**
Register items can only be created one at a time. If a client needs to create multiple register items for an event, there's a risk that some would succeed and some would fail, leaving a partially-finished state.

**After**
- Register items can be created using the same format as before, with no client changes
- Register items can also be created in batches
- Batches are created in a transaction, so a single failure in the batch rolls the whole batch back. This allows a client to send all items in a single request with a guaranteed done or undone state.