### PR TITLE
enhance/charts settings

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -66,7 +66,7 @@ class ChartsController < ApplicationController
     end
 
     def chart_params
-      params.require(:chart).permit(:register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period)
+      params.require(:chart).permit(:register_id, :name, :chart_type, :color_scheme, :default_time_range, :invert_sign, :report_period, default_timezones: [])
     end
 
     # this is an aliased parameter for several underlying chart columns

--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -3,7 +3,8 @@
 class Chart < ApplicationRecord
   audited associated_with: :dashboard
 
-  REPORT_PERIODS = %w[day week month quarter year]
+  VALID_REPORT_PERIODS = %w[day week month quarter year].freeze
+  VALID_TIME_RANGES = %w[today yesterday last_week last_month last_year ytd].freeze
 
   validates :name,
     presence: true,
@@ -18,9 +19,23 @@ class Chart < ApplicationRecord
   validates :report_period,
     presence: true,
     inclusion: {
-      in: REPORT_PERIODS,
+      in: VALID_REPORT_PERIODS,
       message: "%{value} is not a valid report period"
     }
+  validates :default_time_range,
+    presence: true,
+    inclusion: {
+      in: VALID_TIME_RANGES,
+      # any string with format 'last_n_days' where n is Integer && n > 0 is valid
+      unless: -> { default_time_range&.match?(/\Alast_[1-9]\d*_days\z/) },
+      message: "%{value} is not a valid time range"
+    }
+  validates :default_timezones, presence: true
+  validates_each :default_timezones do |record, attr, value|
+    value&.each do |zone|
+      record.errors.add(attr, "#{zone} is not a valid time zone") unless ActiveSupport::TimeZone[zone]
+    end
+  end
 
   belongs_to :dashboard, inverse_of: :charts
   belongs_to :register, inverse_of: :charts
@@ -42,6 +57,59 @@ class Chart < ApplicationRecord
     groups.transform_keys do |key|
       raise "#{key} is not a valid alias on this chart's groups" unless meta.key? key
       meta[key]
+    end
+  end
+
+  def default_timezone
+    default_timezones.first
+  end
+
+  def time_range_bounds(timezone: default_timezone)
+    zone = if default_timezones.include?(timezone)
+             timezone
+           else
+             raise ArgumentError, "Invalid timezone #{timezone}. Must be one of: #{default_timezones.join(', ')}"
+           end
+
+    Time.use_zone(zone) do
+      case default_time_range
+      when 'today'
+        {
+          start_at: Time.current.beginning_of_day.iso8601,
+          end_at: Time.current.end_of_day.iso8601
+        }
+      when 'yesterday'
+        {
+          start_at: Time.current.yesterday.beginning_of_day.iso8601,
+          end_at: Time.current.yesterday.end_of_day.iso8601
+        }
+      when 'last_week'
+        {
+          start_at: Time.current.last_week.iso8601,
+          end_at: Time.current.last_week.end_of_week.iso8601
+        }
+      when 'last_month'
+        {
+          start_at: Time.current.last_month.beginning_of_month.iso8601,
+          end_at: Time.current.last_month.end_of_month.iso8601
+        }
+      when 'last_year'
+        {
+          start_at: Time.current.last_year.beginning_of_year.iso8601,
+          end_at: Time.current.last_year.end_of_year.iso8601
+        }
+      when 'ytd'
+        {
+          start_at: Time.current.beginning_of_year.iso8601,
+          end_at: Time.current.iso8601
+        }
+      when /\Alast_([1-9]\d*)_days\z/ # last_n_days where n > 0
+        days = $1.to_i
+        {
+          start_at: (Time.current.beginning_of_day - days.days).iso8601,
+          end_at: Time.current.yesterday.end_of_day.iso8601
+        }
+      end
     end
   end
 end

--- a/app/serializers/chart_serializer.rb
+++ b/app/serializers/chart_serializer.rb
@@ -1,5 +1,5 @@
 class ChartSerializer < ActiveModel::Serializer
-  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period, :report_groups
+  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period, :default_timezone, :default_time_range, :report_groups
 
   def report_groups
     object.aliased_groups()

--- a/app/serializers/chart_serializer.rb
+++ b/app/serializers/chart_serializer.rb
@@ -1,7 +1,11 @@
 class ChartSerializer < ActiveModel::Serializer
-  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period, :default_timezone, :default_time_range, :report_groups
+  attributes :id, :dashboard_id, :register_id, :name, :chart_type, :color_scheme, :invert_sign, :report_period, :default_timezones, :default_time_range, :time_range_bounds, :report_groups
 
   def report_groups
-    object.aliased_groups()
+    object.aliased_groups
+  end
+
+  def time_range_bounds
+    object.time_range_bounds
   end
 end

--- a/db/migrate/20241024214322_add_time_zones_and_time_range_to_charts.rb
+++ b/db/migrate/20241024214322_add_time_zones_and_time_range_to_charts.rb
@@ -1,0 +1,6 @@
+class AddTimeZonesAndTimeRangeToCharts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charts, :default_timezones, :string, array: true, null: false, default: ['America/New_York']
+    add_column :charts, :default_time_range, :string, null: false, default: 'ytd'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_17_201024) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_24_214322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -129,6 +129,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_17_201024) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "invert_sign", default: false, null: false
+    t.string "default_timezones", default: ["America/New_York"], null: false, array: true
+    t.string "default_time_range", default: "ytd", null: false
     t.index ["chart_type"], name: "index_charts_on_chart_type"
     t.index ["dashboard_id"], name: "index_charts_on_dashboard_id"
     t.index ["register_id"], name: "index_charts_on_register_id"

--- a/spec/factories/chart.rb
+++ b/spec/factories/chart.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     sequence(:name) { |n| "Chart #{n}" }
     sequence :chart_type, %i[bar line heat_map random pie].cycle
     report_period { 'month' }
+    default_timezones { ['America/New_York', 'America/Los_Angeles'] }
+    default_time_range { 'ytd' }
     meta0 { register.meta.key?('meta0') ? false : nil }
     meta1 { register.meta.key?('meta1') ? false : nil }
     meta2 { register.meta.key?('meta2') ? false : nil }

--- a/spec/models/chart_spec.rb
+++ b/spec/models/chart_spec.rb
@@ -1,47 +1,223 @@
 require 'rails_helper'
 
 RSpec.describe Chart, type: :model do
-  let(:chart) { FactoryBot.create :chart }
+  include ActiveSupport::Testing::TimeHelpers
 
-  describe 'aliased_groups' do
-    it 'produces an aliased report_groups hash' do
-      expect(chart.aliased_groups).to eq({
-        'customer_id' => false,
-        'income_account' => false,
-        'entity_type' => false,
-        'entity_id' => false
-      })
+  describe 'validations' do
+    let(:chart) { FactoryBot.build :chart }
+    before do
+      chart.dashboard.save!
+      chart.register.save!
+    end
+
+    context 'name' do
+      it 'is required' do
+        chart.name = nil
+        expect(chart).not_to be_valid
+        expect(chart.errors[:name]).to include("can't be blank")
+      end
+
+      it 'is unique within the scope of dashboard and register' do
+        FactoryBot.create(:chart, name: 'Revenue', dashboard: chart.dashboard, register: chart.register)
+        chart.name = 'Revenue'
+        expect(chart).not_to be_valid
+        expect(chart.errors[:name]).to include('Revenue already exists as a chart name for this dashboard and register')
+      end
+    end
+
+    context 'chart_type' do
+      it 'is required' do
+        chart.chart_type = nil
+        expect(chart).not_to be_valid
+        expect(chart.errors[:chart_type]).to include("can't be blank")
+      end
+    end
+
+    context 'color_scheme' do
+      it 'is required' do
+        chart.color_scheme = nil
+        expect(chart).not_to be_valid
+        expect(chart.errors[:color_scheme]).to include("can't be blank")
+      end
+    end
+
+    context 'report_period' do
+      it 'is required' do
+        chart.report_period = nil
+        expect(chart).not_to be_valid
+        expect(chart.errors[:report_period]).to include("can't be blank")
+      end
+
+      it 'must be one of the valid periods' do
+        chart.report_period = 'invalid_period'
+        expect(chart).not_to be_valid
+        expect(chart.errors[:report_period]).to include('invalid_period is not a valid report period')
+      end
+    end
+
+    context 'default_time_range' do
+      it 'is required' do
+        chart.default_time_range = ''
+        expect(chart).not_to be_valid
+        expect(chart.errors[:default_time_range]).to be_present
+      end
+
+      it 'accepts static time ranges' do
+        static_ranges = %w[today yesterday last_week last_month last_year ytd]
+        static_ranges.each do |range|
+          chart.default_time_range = range
+          expect(chart).to be_valid
+        end
+      end
+
+      it 'accepts properly formatted last_n_days ranges' do
+        dynamic_ranges = %w[last_7_days last_30_days last_90_days last_365_days last_123456789_days]
+        dynamic_ranges.each do |range|
+          chart.default_time_range = range
+          expect(chart).to be_valid
+        end
+      end
+
+      it 'rejects invalid time ranges' do
+        invalid_ranges = %w[last_-1_days last_0_days last_007_days invalid]
+        invalid_ranges.each do |range|
+          chart.default_time_range = range
+          expect(chart).not_to be_valid
+          expect(chart.errors[:default_time_range]).to be_present
+        end
+      end
+    end
+
+    context 'default_timezones' do
+      it 'is required' do
+        chart.default_timezones = nil
+        expect(chart).not_to be_valid
+        expect(chart.errors[:default_timezones]).to include("can't be blank")
+      end
+
+      it 'must contain only valid time zones' do
+        chart.default_timezones = ['Invalid/Zone']
+        expect(chart).not_to be_valid
+        expect(chart.errors[:default_timezones]).to include('Invalid/Zone is not a valid time zone')
+      end
+
+      it 'is valid with only valid time zones' do
+        chart.default_timezones = ['UTC', 'America/New_York']
+        expect(chart).to be_valid
+      end
     end
   end
 
-  describe 'unaliased_groups' do
-    it 'can produce an unaliased report_groups hash' do
-      expect(chart.unaliased_groups).to eq({
-        'meta0' => false,
-        'meta1' => false,
-        'meta2' => false,
-        'meta3' => false
-      })
-    end
-  end
+  describe 'instance methods' do
+    let(:chart) { FactoryBot.create :chart }
 
-  describe 'unalias_groups!' do
-    it 'de-aliases a valid report_groups hash' do
-      report_groups = {
-        'income_account' => false,
-        'customer_id' => true
-      }
-      unaliased_groups = chart.unalias_groups!(report_groups)
-      expect(unaliased_groups).to eq({ 'meta1' => false, 'meta0' => true })
+    describe '#aliased_groups' do
+      it 'produces an aliased report_groups hash' do
+        expect(chart.aliased_groups).to eq({
+          'customer_id' => false,
+          'income_account' => false,
+          'entity_type' => false,
+          'entity_id' => false
+        })
+      end
     end
 
-    it 'raises an error for invalid report_groups' do
-      report_groups = {
-        'not_a_real_label' => false
-      }
-      expect do
-        chart.unalias_groups!(report_groups)
-      end.to raise_error(StandardError)
+    describe '#unaliased_groups' do
+      it 'can produce an unaliased report_groups hash' do
+        expect(chart.unaliased_groups).to eq({
+          'meta0' => false,
+          'meta1' => false,
+          'meta2' => false,
+          'meta3' => false
+        })
+      end
+    end
+
+    describe '#unalias_groups!' do
+      it 'de-aliases a valid report_groups hash' do
+        report_groups = {
+          'income_account' => false,
+          'customer_id' => true
+        }
+        unaliased_groups = chart.unalias_groups!(report_groups)
+        expect(unaliased_groups).to eq({ 'meta1' => false, 'meta0' => true })
+      end
+
+      it 'raises an error for invalid report_groups' do
+        report_groups = {
+          'not_a_real_label' => false
+        }
+        expect do
+          chart.unalias_groups!(report_groups)
+        end.to raise_error(StandardError)
+      end
+    end
+
+    describe '#default_timezone' do
+      it 'returns the first timezone in the array of default timezones' do
+        expect(chart.default_timezone).to eq('America/New_York')
+      end
+    end
+
+    describe '#time_range_bounds' do
+      before do
+        chart.update!(default_timezones: %w[America/New_York UTC Asia/Tokyo])
+      end
+
+      around do |example|
+        travel_to Time.zone.local(2024, 1, 15, 4, 0, 0) do
+          example.run
+        end
+      end
+
+      context 'with invalid timezone' do
+        it 'raises ArgumentError' do
+          expect {
+            chart.time_range_bounds(timezone: 'Invalid/Zone')
+          }.to raise_error(ArgumentError, /Invalid timezone/)
+        end
+      end
+
+      context 'with valid timezone' do
+        shared_examples 'returns correct time bounds' do |timezone, expected_offset|
+          it "returns correct bounds for #{timezone}" do
+            result = chart.time_range_bounds(timezone: timezone)
+
+            expect(result[:start_at]).to be_a(String)
+            expect(result[:end_at]).to be_a(String)
+            expect(result[:start_at].to_time.utc_offset).to eq(expected_offset)
+            expect(result[:end_at].to_time.utc_offset).to eq(expected_offset)
+          end
+        end
+
+        it_behaves_like 'returns correct time bounds', 'UTC', 0
+        it_behaves_like 'returns correct time bounds', 'America/New_York', -5 * 60 * 60 # -5 hours in seconds
+        it_behaves_like 'returns correct time bounds', 'Asia/Tokyo', 9 * 60 * 60 # 9 hours in seconds
+      end
+
+      context 'with last_n_days time range' do
+        [7, 30, 90].each do |days|
+          context "with last_#{days}_days" do
+            before { allow(chart).to receive(:default_time_range).and_return("last_#{days}_days") }
+
+            it "returns correct bounds for last #{days} days" do
+              result = chart.time_range_bounds
+
+              expect(result[:start_at]).to eq((Time.current.in_time_zone(chart.default_timezone).beginning_of_day - days.days).iso8601)
+              expect(result[:end_at]).to eq(Time.current.in_time_zone(chart.default_timezone).yesterday.end_of_day.iso8601)
+            end
+
+            it "maintains correct day count across timezones" do
+              ['UTC', 'America/New_York', 'Asia/Tokyo'].each do |zone|
+                result = chart.time_range_bounds(timezone: zone)
+                day_count = (result[:start_at].to_date..result[:end_at].to_date).to_a.size
+
+                expect(day_count).to eq(days)
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/charts_spec.rb
+++ b/spec/requests/charts_spec.rb
@@ -20,6 +20,11 @@ describe "Charts API", type: :request do
         chart_type: { type: :string },
         color_scheme: { type: :string },
         report_period: { type: :string },
+        default_time_range: { type: :string },
+        default_timezones: {
+          type: :array,
+          items: { type: :string }
+        },
         report_groups: {
           type: :object,
           additionalProperties: { type: :boolean }
@@ -38,6 +43,11 @@ describe "Charts API", type: :request do
         chart_type: { type: :string },
         color_scheme: { type: :string },
         report_period: { type: :string },
+        default_time_range: { type: :string },
+        default_timezones: {
+          type: :array,
+          items: { type: :string }
+        },
         report_groups: {
           type: :object,
           additionalProperties: { type: :boolean }
@@ -103,7 +113,9 @@ describe "Charts API", type: :request do
             income_account: true,
             entity_type: true,
             entity_id: true
-          }
+          },
+          default_time_range: 'last_year',
+          default_timezones: ['America/New_York', 'America/Los_Angeles']
         }
       }
       let(:report_period) { 'year' }
@@ -113,6 +125,8 @@ describe "Charts API", type: :request do
 
         run_test! do |response|
           data = JSON.parse(response.body)
+          expect(data['chart']['default_timezones']).to match_array(['America/New_York', 'America/Los_Angeles'])
+          expect(data['chart']['default_time_range']).to eq('last_year')
           expect(data['chart']['report_groups']['customer_id']).to be false
           expect(data['chart']['report_groups']['income_account']).to be true
           expect(data['chart']['report_groups']['entity_type']).to be true
@@ -178,7 +192,9 @@ describe "Charts API", type: :request do
       parameter name: :chart_update, in: :body, schema: update_chart_schema
       let(:chart_update) {
         {
-          name: name
+          name: name,
+          default_time_range: 'last_7_days',
+          default_timezones: ['America/New_York', 'UTC']
         }
       }
       let(:name) { 'Test Chart' }
@@ -189,6 +205,8 @@ describe "Charts API", type: :request do
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data['chart']['name']).to eq(name)
+          expect(data['chart']['default_time_range']).to eq('last_7_days')
+          expect(data['chart']['default_timezones']).to match_array(['America/New_York', 'UTC'])
         end
       end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -70,13 +70,22 @@ RSpec.configure do |config|
               name: { type: :string },
               chart_type: { type: :string },
               color_scheme: { type: :string },
+              default_time_range: { type: :string },
+              default_timezones: {
+                type: :array,
+                items: { type: :string }
+              },
+              time_range_bounds: {
+                type: :object,
+                additionalProperties: { type: :string }
+              },
               report_period: { type: :string },
               report_groups: {
                 type: :object,
                 additionalProperties: { type: :boolean }
               }
             },
-            required: %i[id dashboard_id register_id name chart_type color_scheme report_period report_groups]
+            required: %i[id dashboard_id register_id name chart_type color_scheme default_time_range default_timezones time_range_bounds report_period report_groups]
           }
         }
       }


### PR DESCRIPTION
**Before**
No `Chart` fields for controlling `Report` time ranges and timezone

**After**
- Charts have `default_timezones` and a `default_time_range` which are used to determine the default time settings used for `Reports`
- `Charts` serialize the expected `start_at` and `end_at` associated with the `default_time_range` for the `Chart`
- Test coverage for validations, serialization, settings fields, and new `time_range_bounds` instance method