### PR TITLE
log actual task finish, normalize report cache keys

### DIFF
--- a/app/jobs/cache_warm_up_job.rb
+++ b/app/jobs/cache_warm_up_job.rb
@@ -13,7 +13,7 @@ class CacheWarmUpJob < ApplicationJob
       return
     end
 
-    puts("CacheWarmUpJob successful. Exiting.")
+    puts("CacheWarmUpJob all jobs successful. Exiting.")
   rescue Timeout::Error
     puts("CacheWarmUpJob timed out after 2 hours, cache: #{cache}")
   rescue => e
@@ -30,8 +30,9 @@ class CacheWarmUpJob < ApplicationJob
     sleep(delay_duration) # sleep to decrease DB collisions on multiple Rails instances
 
     Timeout.timeout(2.hours) do
-      puts("CacheWarmUpJob Warming up app_activity_stats cache with #{app_ids.size} apps and cutoff date #{date_cutoff}")
+      puts("CacheWarmUpJob warming up app_activity_stats cache with #{app_ids.size} apps and cutoff date #{date_cutoff}")
       App.cache_stats_for!(app_ids:, date_cutoff:)
+      puts("CacheWarmUpJob completed for app_activity_stats")
     end
   end
 
@@ -42,7 +43,7 @@ class CacheWarmUpJob < ApplicationJob
     sleep(delay_duration)
 
     Timeout.timeout(2.hours) do
-      puts("CacheWarmUpJob Warming up report_charts with #{chart_ids.size} charts")
+      puts("CacheWarmUpJob warming up report_charts with #{chart_ids.size} charts")
       report = Services::Report.new()
       charts = Chart.where(id: chart_ids) || []
       charts.each do |chart|
@@ -61,6 +62,7 @@ class CacheWarmUpJob < ApplicationJob
           report.send(chart.report_type, report_params)
         end
       end
+      puts("CacheWarmUpJob completed warmup for all charts")
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.cache_store = :memory_store
+    # config.cache_store = :memory_store
+    config.cache_store = :file_store, Rails.root.join("tmp/cache")
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -20,7 +20,17 @@ module Services
     end
 
     def cache_key(stat, args)
-      "simple_stat_lookup/#{stat}_#{args.to_s}"
+      # Normalize args to ensure consistent cache keys, removing empty values
+      # and placing into a consistent order
+      args_hash = args.is_a?(Hash) ? args : args.to_h
+      cleaned_args = args_hash.reject { |_, v| v.nil? || v.to_s.empty? }
+      normalized_args = cleaned_args.transform_values(&:to_s)
+                                   .sort_by { |k, _| k.to_s }
+                                   .to_h
+      args_string = normalized_args.map { |k, v| "#{k}:#{v}" }.join('_')
+      key = "simple_stat_lookup/#{stat}"
+      key += "_#{args_string}" unless args_string.empty?
+      key
     end
 
     private

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Services::Report do
 
     it 'produces a valid cache key' do
       key = report.send(:cache_key, 'count', args)
-      expect(key).to eq("simple_stat_lookup/count_{:start_at=>\"2023-01-01T00:00:00-04:00\", :end_at=>\"2023-12-31T23:59:59-04:00\", :register_id=>#{args[:register_id]}}")
+      expect(key).to eq("simple_stat_lookup/count_end_at:2023-12-31T23:59:59-04:00_register_id:#{args[:register_id]}_start_at:2023-01-01T00:00:00-04:00")
     end
 
     it 'only includes specified dates' do


### PR DESCRIPTION
**Before**
Cache warmup does not work as expected

**After**
- pre-warming the cache prevents misses during user session as expected
- cache key is normalized to hit regardless of arg presentation
- logging is transparent about when tasks are ending
- Develop defaults to file store for easier debugging