### PR TITLE
do not pull the entire table if the app ids are not defined

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -153,6 +153,7 @@ class App < ApplicationRecord
   end
 
   def self.stats_for(app_ids:, time_range:, included_dates:)
+    return {} if app_ids.blank?
     activity_groups = activity_groups_for(app_ids:, time_range:)
     format_activity(activity_groups:, app_ids:, included_dates:)
   end


### PR DESCRIPTION
**Before**
Activity stats queries time out, despite caching mechanisms. This is caused by an extra query that pull all apps, for the entire date range:
![Screenshot 2024-11-04 at 2 35 48 PM](https://github.com/user-attachments/assets/ca168f73-dafe-4add-acba-607a9e7eb18b)


**After**
We only make the call for missing data, per the original intent
![Screenshot 2024-11-04 at 2 32 57 PM](https://github.com/user-attachments/assets/6e6787c4-691f-4401-8d13-a2a1b1974d22)
