### PR TITLE
allow json meta, unique handling at controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::API
 
   rescue_from ActiveRecord::RecordInvalid, with: :render_invalid_record
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActiveRecord::RecordNotUnique, with: :render_not_unique
   rescue_from CanCan::AccessDenied, with: :render_unauthorized
   rescue_from EnvHandler::MissingEnvVariableError, with: :render_env_error
 
@@ -54,6 +55,10 @@ class ApplicationController < ActionController::API
 
   def render_not_found(err)
     render status: :not_found
+  end
+
+  def render_not_unique(err)
+    render json: {errors: err}, status: :conflict
   end
 
   def render_env_error(err)

--- a/test/controllers/register_items_controller_test.rb
+++ b/test/controllers/register_items_controller_test.rb
@@ -226,6 +226,66 @@ class RegisterItemsControllerTest < ActionDispatch::IntegrationTest
     assert_not RegisterItem.exists?(unique_key: "ABC123")
   end
 
+  test "should rollback if key has been used in a separate transaction" do
+    post register_items_url,
+      params: {
+        unique_key: "ABC123",
+        description: "Test Item",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        originated_at: Time.current
+      },
+      headers: @auth_headers,
+      as: :json
+
+    assert_response :success
+    response_item = JSON.parse(response.body)
+    assert_equal "ABC123", response_item["unique_key"]
+
+    post register_items_url,
+      params: {
+        unique_key: "ABC123",
+        description: "Test Item",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        originated_at: Time.current
+      },
+      headers: @auth_headers,
+      as: :json
+
+    assert_response :unprocessable_entity
+    response_item = JSON.parse(response.body)
+    assert_equal response_item["unique_key"], ["has already been taken"]
+  end
+
+
+
+  test "accepts a meta attribute of JSON content" do
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        income_account:  {"example_json": 1}
+      }
+    ]
+
+    assert_difference('RegisterItem.count', 1) do
+      post bulk_create_register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+
+    assert_response :success
+    expected_output = "{\"example_json\"=>1}" # the test interpolates the response and prints as a hash; it's actually JSON
+    assert_equal JSON.parse(response.body)[0]["income_account"], expected_output
+  end
+
   test "should rollback if any item has invalid ownership" do
     items_params = [
       {


### PR DESCRIPTION
**Before**

1. We error on duplicate keys instead of returning a 422.
![Screenshot 2024-11-07 at 8 18 04 AM](https://github.com/user-attachments/assets/1d8e6c02-c55e-4d87-b75e-43ed616ef421)

2. We error if a meta column includes JSON.
![Screenshot 2024-11-07 at 12 13 23 PM](https://github.com/user-attachments/assets/6f662e06-adbf-4f89-bbf5-bb3a10d22d73)

**After**
1. We catch record not unique at the application level, and remove the (incorrect) error handling from bulk_update
2. We blank-permit hashes for meta columns.