### PR TITLE
allow numeric meta valus

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -160,7 +160,7 @@ class RegisterItemsController < ApplicationController
       @register.meta.each do |column, label|
         next unless register_item_params[label]
         case register_item_params[label]
-        when String
+        when String, Integer, Float, BigDecimal
           permitted_params[column] = register_item_params[label]
         when ActionController::Parameters
           permitted_params[column] = register_item_params[label].to_json

--- a/test/controllers/register_items_controller_test.rb
+++ b/test/controllers/register_items_controller_test.rb
@@ -283,6 +283,29 @@ class RegisterItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal JSON.parse(response.body)[0]["income_account"], "{\"example_json\":1}"
   end
 
+  test "accepts a meta attribute of numeric content" do
+    items_params = [
+      {
+        unique_key: "ABC123",
+        description: "Test Item 1",
+        register_id: @register.id,
+        amount: 100,
+        units: 'USD',
+        income_account: 2
+      }
+    ]
+
+    assert_difference('RegisterItem.count', 1) do
+      post bulk_create_register_items_url,
+        params: { register_items: items_params },
+        headers: @auth_headers,
+        as: :json
+    end
+
+    assert_response :success
+    assert_equal JSON.parse(response.body)[0]["income_account"], "2"
+  end
+
   test "should rollback if any item has invalid ownership" do
     items_params = [
       {


### PR DESCRIPTION
**Before**
We reject meta values that are not String or JSON (hash)

**After**
We accept meta values of common numeric types, which will be coerced into strings. This re-enables previous behavior.