### PR TITLE
enhance/audits_ownership

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem "scenic", "~> 1.8"
+gem 'diffy'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.1)
     diff-lcs (1.5.0)
+    diffy (3.4.2)
     discard (1.2.1)
       activerecord (>= 4.2, < 8)
     dotenv (2.8.1)
@@ -323,6 +324,7 @@ DEPENDENCIES
   cancancan
   devise_invitable (~> 2.0)
   devise_token_auth
+  diffy
   discard (~> 1.2)
   dotenv-rails
   factory_bot_rails

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -7,7 +7,7 @@ class App < ApplicationRecord
 
   MINIMUM_PORT_NUMBER = 3001
 
-  audited
+  audited owned_audits: true
   has_associated_audits
 
   belongs_to :owner, polymorphic: true

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -27,6 +27,8 @@ class App < ApplicationRecord
 
   before_validation :set_defaults
 
+  alias_attribute :reference_name, :name
+
   def descriptive_name_unique?
     # custom validator to factor for deleted apps
     if owner

--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -47,6 +47,8 @@ class Chart < ApplicationRecord
   belongs_to :dashboard, inverse_of: :charts
   belongs_to :register, inverse_of: :charts
 
+  alias_attribute :reference_name, :name
+
   def aliased_groups
     register.meta.each_with_object({}) do |(column, label), groups|
       groups[label] = __send__(column)

--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -1,7 +1,7 @@
 # app/model/chart.rb
 
 class Chart < ApplicationRecord
-  audited associated_with: :dashboard
+  audited associated_with: :dashboard, owned_audits: true
 
   VALID_REPORT_PERIODS = %w[day week month quarter year all].freeze
   VALID_REPORT_TYPES = %w[item_count item_sum item_average].freeze

--- a/app/models/credential_set.rb
+++ b/app/models/credential_set.rb
@@ -12,6 +12,8 @@ class CredentialSet < ApplicationRecord
 
   before_create :set_external_id
 
+  alias_attribute :reference_name, :name
+
   def credentials
     @credentials ||= CredentialSetCredentials.find_or_build_by_user_and_name owner, credentials_name
   end

--- a/app/models/credential_set.rb
+++ b/app/models/credential_set.rb
@@ -2,7 +2,7 @@ class CredentialSet < ApplicationRecord
   include Ownable
   include Permissible
 
-  audited
+  audited owned_audits: true
 
   belongs_to :owner, polymorphic: true
   has_many :permissions, as: :permissible

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -26,4 +26,6 @@ class Dashboard < ApplicationRecord
   has_many :permitted_users, through: :permissions, source: :user, inverse_of: :permitted_dashboards
 
   has_many :charts, inverse_of: :dashboard
+
+  alias_attribute :reference_name, :name
 end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -2,7 +2,7 @@ class Dashboard < ApplicationRecord
   include Ownable
   include Permissible
 
-  audited
+  audited owned_audits: true
   has_associated_audits
 
   validates :owner,

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -16,6 +16,10 @@ class Manifest < ApplicationRecord
 
     after_save :create_activity_entry
 
+    def reference_name
+        app.reference_name
+    end
+
     def copy_to_app!(new_app)
         new_manifest = self.dup
         new_manifest.app_id = new_app.name

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -2,7 +2,7 @@ class Manifest < ApplicationRecord
     include Ownable
     include Permissible
 
-    audited associated_with: :app
+    audited associated_with: :app, owned_audits: true
 
     validates :app_id, presence: true
     validates :content, presence: true

--- a/app/models/manifest_draft.rb
+++ b/app/models/manifest_draft.rb
@@ -2,7 +2,7 @@ class ManifestDraft < ApplicationRecord
   include Ownable
   include Permissible
 
-  audited
+  audited owned_audits: true
 
   belongs_to :app
   belongs_to :manifest

--- a/app/models/org_role.rb
+++ b/app/models/org_role.rb
@@ -9,4 +9,6 @@ class OrgRole < ApplicationRecord
 
   belongs_to :organization
   belongs_to :user
+
+  alias_attribute :reference_name, :role
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,7 @@
 class Organization < ApplicationRecord
   audited
   has_associated_audits
+  has_owned_audits
 
   has_many :owned_apps, class_name: 'App', as: :owner
   has_many :owned_manifests, class_name: 'Manifest', as: :owner

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,8 +23,15 @@ class Organization < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
+  alias_attribute :reference_name, :name
+
   def admin?(user)
     org_roles.find_by(user: user)&.role == 'admin'
+  end
+
+  def all_audits
+    audits = super
+    audits.or(Audited.audit_class.where(auditable: self.users))
   end
 
   private

--- a/app/models/owned_audit.rb
+++ b/app/models/owned_audit.rb
@@ -1,0 +1,5 @@
+# app/models/owned_audit.rb
+
+class OwnedAudit < Audited::Audit
+  belongs_to :owner, polymorphic: true, optional: true
+end

--- a/app/models/owned_audit.rb
+++ b/app/models/owned_audit.rb
@@ -2,4 +2,54 @@
 
 class OwnedAudit < Audited::Audit
   belongs_to :owner, polymorphic: true, optional: true
+
+  delegate :name, :email, to: :user, prefix: true, allow_nil: true
+  delegate :reference_name, to: :auditable, allow_nil: true
+  alias_attribute :reference_type, :auditable_type
+  alias_attribute :reference_id, :auditable_id
+
+  default_scope do
+    includes(:user, :auditable)
+  end
+
+  def hash_diff(old_value: {}, new_value: {})
+    formatted_old_value, formatted_new_value = [old_value, new_value].map do |value|
+      parsed = value.is_a?(String) ? JSON.parse(value) : value
+      parsed = deep_sort(parsed)
+      JSON.pretty_generate(parsed) + "\n"
+    end
+    diff_text = Diffy::Diff.new(formatted_old_value, formatted_new_value, context: 3).to_s
+    diff_text.blank? ? nil : strip_left_whitespace(diff_text)
+  end
+
+  private
+
+  def deep_sort(obj)
+    case obj
+    when Hash
+      obj.sort.to_h.transform_values { |v| deep_sort(v) }
+    when Array
+      obj.map { |v| deep_sort(v) }
+    else
+      obj
+    end
+  end
+
+  def strip_left_whitespace(text)
+    lines = text.split("\n")
+    return text if lines.size < 2
+
+    min_indent = lines.map { |line| line.index(/\S/, 1) }.compact.min
+
+    adjusted_lines = lines.map do |line|
+      if line.present? && line.length >= min_indent
+        prefix = line[0]
+        preserved = line[min_indent..]
+        prefix + preserved
+      else
+        line
+      end
+    end
+    adjusted_lines.join("\n")
+  end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,7 +1,7 @@
 class Permission < ApplicationRecord
   include PermissionConstants
 
-  audited
+  audited associated_with: :permissible, owned_audits: true
 
   belongs_to :user
   belongs_to :permissible, polymorphic: true

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -25,6 +25,8 @@ class Register < ApplicationRecord
   before_validation :set_defaults
   after_create :create_gross_revenue_chart
 
+  alias_attribute :reference_name, :name
+
   private
     def set_defaults
       self.sample_type ||= 'increment'

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -3,7 +3,7 @@ class Register < ApplicationRecord
   include Ownable
   include Permissible
 
-  audited
+  audited owned_audits: true
   has_associated_audits
 
   # Register identity basics

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -7,7 +7,7 @@ class RegisterItem < ApplicationRecord
   include Permissible
   include Search
 
-  audited associated_with: :register
+  audited associated_with: :register, owned_audits: true
 
   # includes only non-meta searchable columns
   # meta columns are handled by self.search

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -16,6 +16,10 @@ class RegisterItem < ApplicationRecord
   belongs_to :register
   has_many :activity_entries
 
+  default_scope do
+    includes(:register)
+  end
+
   @@initialized_registers = {}
   @@initialization_lock = Mutex.new
 
@@ -36,6 +40,10 @@ class RegisterItem < ApplicationRecord
 
   # Denormalized from register
   before_create :set_register_attrs
+
+  def reference_name
+    register.reference_name
+  end
 
   def set_register_attrs
     self.units ||= register.units

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,4 +10,6 @@ class Tag < ApplicationRecord
   validates :name, uniqueness: { 
     scope: [:taggable_type, :taggable_id, :context] },
     strict: TagExists
+
+  alias_attribute :reference_name, :name
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,10 +3,10 @@ class TagExists < StandardError
 end
 
 class Tag < ApplicationRecord
-  audited associated_with: :taggable
+  audited associated_with: :taggable, owned_audits: true
 
   belongs_to :taggable, polymorphic: true
-  
+
   validates :name, uniqueness: { 
     scope: [:taggable_type, :taggable_id, :context] },
     strict: TagExists

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
   include EnvHandler
 
   audited
+  has_owned_audits
 
   has_and_belongs_to_many :customers
   has_many :org_roles, :dependent => :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User < ActiveRecord::Base
   before_save :set_values_for_individual
   before_create :set_trial_expires_at
 
+  alias_attribute :reference_name, :name
+
   def ensure_aws_role!
     begin
       aws_env_set?

--- a/app/serializers/audit_serializer.rb
+++ b/app/serializers/audit_serializer.rb
@@ -1,4 +1,0 @@
-class AuditSerializer < ActiveModel::Serializer
-  attributes :id, :auditable_id, :auditable_type, :associated_id, :associated_type, :user_id,
-    :action, :audited_changes, :version, :remote_address, :created_at
-end

--- a/app/serializers/owned_audit_serializer.rb
+++ b/app/serializers/owned_audit_serializer.rb
@@ -1,0 +1,47 @@
+class OwnedAuditSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :user_name, :user_email, :reference_id, :reference_type, :reference_name, :action, :audited_changes, :created_at
+
+  def user_name
+    object.user_name || 'Not provided'
+  end
+
+  def user_email
+    object.user_email || 'Not provided'
+  end
+
+  def reference_name
+    object.reference_name || 'Not provided'
+  end
+
+  def audited_changes
+    object.audited_changes.map do |key, value|
+      patch = case object.action
+              when 'create'
+                "[created] #{key}: #{value}"
+              when 'update'
+                if value[0].is_a?(Hash)
+                  object.hash_diff(new_value: value[0], old_value: value[1]) || "#{key}: Whitespace changes only"
+                else
+                  "- #{key}: #{value[0]}\n+ #{key}: #{value[1]}"
+                end
+              when 'destroy'
+                "[destroyed] #{key}: #{value}"
+              end
+
+      old_value, new_value = case object.action
+                             when 'create'
+                               [nil, value]
+                             when 'update'
+                               value
+                             when 'destroy'
+                               [value, nil]
+                             end
+      {
+        attribute: key,
+        patch:,
+        old_value:,
+        new_value:
+      }
+    end
+  end
+end

--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,0 +1,18 @@
+# config/initializers/audited.rb
+require 'audited/auditor_extension'
+
+Audited.config do |config|
+  config.audit_class = "OwnedAudit"
+end
+
+module Audited
+  module Auditor
+    module ClassMethods
+      prepend Audited::Auditor::ClassMethodsExtension
+    end
+
+    module AuditedInstanceMethods
+      prepend Audited::Auditor::AuditedInstanceMethodsExtension
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,12 @@
 
 Rails.application.routes.draw do
   concern :auditable do
-    resources :audits, only: [:index, :show]
+    resources :audits, only: [:index, :show] do
+      collection do
+        get '', to: 'audits#index', constraints: { format: :html }
+        get '', to: 'audits#csv', constraints: { format: :csv }
+      end
+    end
   end
 
   resources :customers

--- a/lib/audited/auditor_extension.rb
+++ b/lib/audited/auditor_extension.rb
@@ -1,0 +1,34 @@
+# lib/audited/auditor_extension.rb
+
+module Audited
+  module Auditor
+    module ClassMethodsExtension
+      def has_owned_audits
+        has_many :owned_audits, as: :owner, class_name: Audited.audit_class.name
+      end
+    end
+
+    module AuditedInstanceMethodsExtension
+      def all_audits
+        Audited.audit_class.unscoped.where(auditable: self)
+          .or(Audited.audit_class.unscoped.where(associated: self))
+          .or(Audited.audit_class.unscoped.where(owner: self))
+          .order(created_at: :desc)
+      end
+
+      protected
+
+      def write_audit(attrs)
+        if audited_options[:owned_audits]
+          attrs[:owner] = if audit_associated_with.nil?
+                            send(:owner)
+                          else
+                            parent = send(audit_associated_with)
+                            parent.send(:owner)
+                          end
+        end
+        super
+      end
+    end
+  end
+end

--- a/lib/audited/auditor_extension.rb
+++ b/lib/audited/auditor_extension.rb
@@ -10,9 +10,10 @@ module Audited
 
     module AuditedInstanceMethodsExtension
       def all_audits
-        Audited.audit_class.unscoped.where(auditable: self)
-          .or(Audited.audit_class.unscoped.where(associated: self))
-          .or(Audited.audit_class.unscoped.where(owner: self))
+        Audited.audit_class
+          .where(auditable: self)
+          .or(Audited.audit_class.where(associated: self))
+          .or(Audited.audit_class.where(owner: self))
           .order(created_at: :desc)
       end
 

--- a/lib/services/report.rb
+++ b/lib/services/report.rb
@@ -86,7 +86,11 @@ module Services
         end
         results = results.group(meta_groups)
       end
-      results = results.__send__(stat ,:amount)
+      results = if stat == 'count'
+                  results.count
+                else
+                  results.__send__(stat ,:amount)
+                end
       results = format(results, args[:group_by_period].present?, args[:group_by].present?, args[:invert_sign])
 
       title = generate_title(stat, args[:group_by_period], args[:group_by])

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe Audited::Audit do
 
     it 'has the all_audits instance methods' do
       expect(organization.respond_to? :all_audits).to be true
-      # all_audits: create org, create org_role, create register, create dashboard, create chart
-      expect(organization.all_audits.count).to eq(5)
-      item
+      # all_audits: create org, create org_role, create user, create register, create dashboard, create chart
       expect(organization.all_audits.count).to eq(6)
+      item
+      expect(organization.all_audits.count).to eq(7)
     end
   end
 end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Audited::Audit do
+  let(:user) { FactoryBot.create :user }
+  let!(:organization) { FactoryBot.create :organization, admin: user }
+  let(:register) { organization.owned_registers.first }
+  let(:item) { FactoryBot.create :register_item, register: }
+
+  describe 'audited models' do
+    context 'audited owned_audits: true' do
+      it 'saves the owner for directly owned resources' do
+        expect(register.audited_options[:owned_audits]).to be true
+        register.update!(meta: { meta0: 'income_account' })
+        expect(register.audits.count).to eq(2)
+        register.audits.each do |audit|
+          expect(audit.owner).to eq(organization)
+        end
+      end
+
+      it 'saves the parents owner for associated resources' do
+        expect(item.audited_options[:owned_audits]).to be true
+        expect(item.audited_options[:associated_with]).to eq(:register)
+        item.update!(amount: 100)
+        expect(item.audits.count).to eq(2)
+        item.audits.each do |audit|
+          expect(audit.owner).to eq(item.register.owner)
+        end
+      end
+    end
+
+    context 'has_owned_audits' do
+      it 'has owned_audits association' do
+        expect(organization.respond_to? :owned_audits).to be true
+        expect(organization.owned_audits.count).to eq(3)
+        item
+        expect(organization.owned_audits.count).to eq(4)
+      end
+    end
+
+    it 'has the all_audits instance methods' do
+      expect(organization.respond_to? :all_audits).to be true
+      # all_audits: create org, create org_role, create register, create dashboard, create chart
+      expect(organization.all_audits.count).to eq(5)
+      item
+      expect(organization.all_audits.count).to eq(6)
+    end
+  end
+end


### PR DESCRIPTION
**Before**
Audits were difficult to collect under a unified model because they were disparately associated

**After**
Audits have an owner determined by the audited resource's, or resource's parent's, owner. This allows for the owner to collect audits for all their directly and indirectly owned resources under a single call.

- [x] formatting happens in serializer
- [x] JSON diff calculator on OwnedAudits model
- [x] audits gatherable via `all_audits` method which can be customized per model if needed
- [ ] Search on app_id, user_id, created_at w/date ranges
- [ ] streaming csv export option
- [ ] tests (currently covered for completed tasks)