### PR TITLE
slow migration to add columns to register_items

### DIFF
--- a/db/migrate/20241115132020_add_invoice_id_app_id_to_register_items.rb
+++ b/db/migrate/20241115132020_add_invoice_id_app_id_to_register_items.rb
@@ -1,0 +1,9 @@
+class AddInvoiceIdAppIdToRegisterItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :register_items, :invoice_id, :integer
+    add_column :register_items, :app_id, :integer
+
+    add_index :register_items, :invoice_id
+    add_index :register_items, :app_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_29_204855) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_15_132020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -252,6 +252,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_29_204855) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "originated_at"
+    t.integer "invoice_id"
+    t.integer "app_id"
+    t.index ["app_id"], name: "index_register_items_on_app_id"
+    t.index ["invoice_id"], name: "index_register_items_on_invoice_id"
     t.index ["originated_at"], name: "index_register_items_on_originated_at"
     t.index ["owner_type", "owner_id"], name: "index_register_items_on_owner_type_and_owner_id"
     t.index ["register_id"], name: "index_register_items_on_register_id"


### PR DESCRIPTION
We would like the ability to re-process the activity stream to reflect changes made to Trivial contracts. To do this safely, we’ll add two new columns to the register items table.

1. `register_items.app_id`, so we can reliably target register items to delete
2. `register_items.invoice_id`. This is a coming soonTM (ETA 12/2/24) feature we’ll use to lock data that has already been reported. Rather than immediately repeat our

release plan and update our re-processing code, we’ll add the column we’ll need now and build in the safeguards from day one.

**Before**
No app_id, invoice_id columns on register_items.

**After**
You guessed it– app_id and invoice_id columns!

Usage and backfill in separate PRs.