### PR TITLE
Feature/activity search

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -32,7 +32,7 @@ class ActivityEntriesController < ApplicationController
     end
     raise 'search required' unless search.any?
 
-    @activity_entries = ActivityEntry.search(@activity_entries, search).order(id: :desc)
+    @activity_entries = ActivityEntry.search(@activity_entries, search).limit(search_result_limit).order(id: :desc)
 
     render json: @activity_entries, status: :ok , adapter: :attributes, each_serializer: ActivityEntryMemberSerializer
   rescue StandardError => exception
@@ -159,7 +159,14 @@ class ActivityEntriesController < ApplicationController
   end
 
   private
+  # These can likely be unified in a future pass
+  # The 20 limit is likely much too low after a misdiagnosed missing index
   MAX_RESULTS = 20
+  MAX_SEARCH_RESULTS = 1000
+
+  def search_result_limit
+    [[(params[:limit] || MAX_SEARCH_RESULTS).to_i, 1].max, MAX_SEARCH_RESULTS].min
+  end
 
   def limit
     [[(params[:limit] || MAX_RESULTS).to_i, 1].max, MAX_RESULTS].min

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -4,7 +4,7 @@ require 'search'
 
 class ActivityEntry < ApplicationRecord
   include Search
-  SEARCHABLE_COLUMNS = %w[ payload diagnostics status register_item_id ].freeze
+  SEARCHABLE_COLUMNS = %w[ id payload diagnostics status register_item_id ].freeze
 
   validates :source, presence: true, if: :is_request?
 
@@ -51,7 +51,7 @@ class ActivityEntry < ApplicationRecord
   end
 
   def resend_kafka
-    self.class.kafka.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: payload["key"])
+    KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: payload["key"])
     return OpenStruct.new(code: 200, message: 'OK')
   end
 

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -51,7 +51,7 @@ class ActivityEntry < ApplicationRecord
   end
 
   def resend_kafka
-    KAFKA.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: payload["key"])
+    self.class.kafka.produce_sync(topic: Services::Kafka.topic, payload: payload.to_json, key: payload["key"])
     return OpenStruct.new(code: 200, message: 'OK')
   end
 

--- a/app/serializers/activity_entry_member_serializer.rb
+++ b/app/serializers/activity_entry_member_serializer.rb
@@ -1,0 +1,7 @@
+class ActivityEntryMemberSerializer < ActiveModel::Serializer
+  attributes :id, :payload, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :created_at
+
+  def app_id
+    object.app.name
+  end
+end

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,1 +1,5 @@
 ActiveModelSerializers.config.adapter = :json
+
+# Disable noisy serializer logging
+require 'active_model_serializers'
+ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
       get 'columns'
       get 'keys'
       post 'keys', action: :refresh_keys
+      post 'search'
     end
 
     member do

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -4,7 +4,7 @@ module Search
   end
 
   JSONB_OPERATORS = %w[? ?& ?| @> @? @@]
-  COMPERATORS = %w[< > <= >= = <> !=]
+  COMPERATORS = %w[< > <= >= = <> != IN]
   PREDICATES = ['IS NULL','IS NOT NULL','IS TRUE','IS NOT TRUE','IS FALSE','IS NOT FALSE']
   ORDERINGS = ['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS FIRST', 'ASC NULLS LAST', 'DESC NULLS LAST']
 
@@ -65,6 +65,10 @@ module Search
           raise InvalidPredicateError unless PREDICATES.include?(predicate)
         else
           raise InvalidOperatorError unless COMPERATORS.include?(operator)
+          if operator == 'IN'
+            raise InvalidPredicateError, 'IN operator requires an array' unless predicate.is_a?(Array)
+            return sanitize_sql_array(["#{query.strip} IN (?)", predicate])
+          end
           query << "#{operator}"
         end
       end

--- a/spec/requests/activity_entries_spec.rb
+++ b/spec/requests/activity_entries_spec.rb
@@ -30,6 +30,104 @@ describe 'Activity Entries API' do
     }
   end
 
+  path '/activity_entries/search' do
+    post 'Search activity entries' do
+      tags 'Activity'
+      security [ { access_token: [], client: [], uid: [], token_type: [] } ]
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :search_params, in: :body, schema: {
+        type: :object,
+        properties: {
+          search: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                c: { type: :string, description: 'Column name' },
+                o: { type: :string, description: 'Operator' },
+                p: {
+                  type: :array,
+                  items: { type: :integer },
+                  description: 'Parameters'
+                }
+              },
+              required: ['c', 'o', 'p']
+            }
+          }
+        },
+        required: ['search']
+      }
+
+      # Test data setup
+      let!(:activity_entry_1) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
+      let!(:activity_entry_2) { FactoryBot.create(:activity_entry, :build, owner: user, app: user_app) }
+      let!(:activity_entry_3) { FactoryBot.create(:activity_entry, :request, owner: user, app: user_app) }
+
+      let(:search_params) {
+        {
+          search: [{
+            c: 'id',
+            o: 'IN',
+            p: [activity_entry_1.id, activity_entry_2.id]
+          }]
+        }
+      }
+
+      # Happy path test
+      response '200', 'Activity entries found' do
+        schema type: :array, items: activity_schema
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          # Test that only requested entries are returned
+          expect(data.length).to eq 2
+          returned_ids = data.map { |entry| entry['id'] }
+          expect(returned_ids).to match_array([activity_entry_1.id, activity_entry_2.id])
+          expect(returned_ids).not_to include(activity_entry_3.id)
+
+          # Test that entries are ordered by id desc
+          expect(returned_ids).to eq returned_ids.sort.reverse
+        end
+      end  # end of 200 response block
+
+      # Test string-based search parameter
+      context 'with string-based search parameter' do
+        let(:search_params) {
+          {
+            search: JSON.generate([{
+              c: 'id',
+              o: 'IN',
+              p: [activity_entry_1.id, activity_entry_2.id]
+            }])
+          }
+        }
+
+        response '200', 'Activity entries found with string-based search' do
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data.length).to eq 2
+            expect(data.map { |entry| entry['id'] }).to match_array([activity_entry_1.id, activity_entry_2.id])
+          end
+        end
+      end  # end of string-based search context
+
+      # Test invalid search
+      context 'with invalid search parameter' do
+        let(:search_params) { { search: [] } }
+
+        response '422', 'Invalid search parameters' do
+          run_test! do |response|
+            expect(response.body).to include('search required')
+          end
+        end
+      end  # end of invalid search context
+
+    end  # end of post 'Search activity entries' block
+  end  # end of path block
+
   path '/activity_entries' do
     get 'Retrieve the list of activity' do
       tags 'Activity'


### PR DESCRIPTION
**Before**
There's no way to pass a list of activity ids to return payloads for

**After**
Search is extended with an `IN` comparator, and `activity_entry` includes `id` in its searchable columns. A new endpoint, `POST activity_entries/search`, allows us to pass a large array that would otherwise overflow the URL.

Example:
```
curl -X POST 'http://localhost:3001/activity_entries/search' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer YOUR-TOKEN-HERE' \
  -d '{
    "search": [
      {
        "c": "id",
        "o": "IN",
        "p": [965, 1063]
      }
    ]
  }'

=> [
{"id":1063,"payload":{"key":"co...,
{"id":965,"payload":{"key":"period.sta...
]
```
 logs, note the `AND (id IN (965,1063))` piece we care about:
 ```
 
Processing by ActivityEntriesController#search as */*
  Parameters: {"search"=>[{"c"=>"id", "o"=>"IN", "p"=>[965, 1063]}], "activity_entry"=>{}}

...

SELECT "activity_entries".* FROM "activity_entries" WHERE ("activity_entries"."app_id" IN (SELECT "apps"."id" FROM "apps" WHERE ("apps"."owner_type" = $1 AND "apps"."owner_id" = $2 OR "apps"."owner_type" = $3 AND "apps"."owner_id" IN ($4, $5, $6, $7, $8, $9))) OR "activity_entries"."app_id" IN (SELECT "apps"."id" FROM "apps" WHERE 1=0)) AND (id IN (965,1063)) ORDER BY "activity_entries"."id" DESC  
```
