### PR TITLE
Feature/activity rerun

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -40,7 +40,7 @@ class ActivityEntriesController < ApplicationController
     render_errors(exception, status: :unprocessable_entity)
   end
 
-  def reprocess
+  def rerun
     @app = current_user.associated_apps.kept.find_by_name!(params[:app_id])
     authorize! :update, @app
     start_at = params.require(:start_at)

--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -35,7 +35,8 @@ class RegisterItemsController < ApplicationController
 
   # POST /register_items
   def create
-    @register_item = RegisterItem.new(register_item_params)
+    @register_item = RegisterItem.new
+    @register_item.assign_attributes(register_item_params)
     @register_item.owner = @register.owner
     authorize! :create, @register_item
     if @register_item.save
@@ -56,7 +57,8 @@ class RegisterItemsController < ApplicationController
       registers = Register.where(id: register_ids).index_by(&:id)
       register_items_attributes = params[:register_items].map do |item_params|
         @register = registers[item_params[:register_id]]
-        register_item = RegisterItem.new(register_item_params(item_params))
+        register_item = RegisterItem.new
+        register_item.assign_attributes(register_item_params(item_params))
         register_item.owner = @register&.owner
         authorize! :create, register_item
         register_item.attributes
@@ -155,7 +157,7 @@ class RegisterItemsController < ApplicationController
 
   def register_item_params(args=nil)
     register_item_params = args || params
-    permitted_params = register_item_params.permit(:app_id, :unique_key, :description, :register_id, :amount, :units, :originated_at)
+    permitted_params = register_item_params.permit(:public_app_id, :unique_key, :description, :register_id, :amount, :units, :originated_at)
     if @register
       @register.meta.each do |column, label|
         next unless register_item_params[label]

--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -155,7 +155,7 @@ class RegisterItemsController < ApplicationController
 
   def register_item_params(args=nil)
     register_item_params = args || params
-    permitted_params = register_item_params.permit(:unique_key, :description, :register_id, :amount, :units, :originated_at)
+    permitted_params = register_item_params.permit(:app_id, :unique_key, :description, :register_id, :amount, :units, :originated_at)
     if @register
       @register.meta.each do |column, label|
         next unless register_item_params[label]

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -14,7 +14,7 @@ class RegisterItem < ApplicationRecord
   SEARCHABLE_COLUMNS = %w[originated_at description amount units unique_key].freeze
 
   belongs_to :register
-  belongs_to :app
+  belongs_to :app, optional: true
   has_many :activity_entries
 
   @@initialized_registers = {}

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -38,8 +38,16 @@ class RegisterItem < ApplicationRecord
   # Denormalized from register
   before_create :set_register_attrs
 
+  # Allow the public app id to derive the internal app id
+  attr_reader :public_app_id
+
   def set_register_attrs
     self.units ||= register.units
+  end
+
+  def public_app_id=(value)
+    @public_app_id = value
+    self.app = App.find_by_name!(value) if value.present?
   end
 
   def resolved_column(label)

--- a/app/models/register_item.rb
+++ b/app/models/register_item.rb
@@ -14,6 +14,7 @@ class RegisterItem < ApplicationRecord
   SEARCHABLE_COLUMNS = %w[originated_at description amount units unique_key].freeze
 
   belongs_to :register
+  belongs_to :app
   has_many :activity_entries
 
   @@initialized_registers = {}

--- a/app/serializers/activity_entry_member_serializer.rb
+++ b/app/serializers/activity_entry_member_serializer.rb
@@ -1,5 +1,5 @@
 class ActivityEntryMemberSerializer < ActiveModel::Serializer
-  attributes :id, :payload, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :created_at
+  attributes :id, :payload, :update_id, :owner_id, :owner_type, :app_id, :register_item_id, :activity_type, :status, :duration_ms, :created_at
 
   def app_id
     object.app.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
       get 'keys'
       post 'keys', action: :refresh_keys
       post 'search'
+      put 'rerun'
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,8 +65,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :activity_entries, only: [:index, :create, :show, :create_from_request, :update] do
+  resources :activity_entries, only: [:index, :create, :show, :update] do
     collection do
+      post '', action: :create_from_request
       get 'stats'
       get 'columns'
       get 'keys'

--- a/lib/services/activity_rerun.rb
+++ b/lib/services/activity_rerun.rb
@@ -1,0 +1,139 @@
+# Usage:
+# ActivityRerun.new(app, start_at).call
+
+# Logging signature:
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Reun started
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Register items deleted. count=1500
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Activity entries reset. count=1500
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Queueing activities. total=10000
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Batch processed. processed=2000 total=10000
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Activities queued. count=10000
+# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Reun completed. deleted=1500 reset=1500 reprocessed=10000
+
+module Services
+
+  class ActivityRerun
+    BATCH_SIZE = 1000
+
+    def initialize(app, start_at)
+      @app = app
+      @start_at = start_at
+      @logger = Rails.logger
+      @last_id = nil
+      @run_id = SecureRandom.random_number(1_000_000).to_s.rjust(6, '0')
+    end
+
+    def call
+      log_info("Reun started")
+      validate_params!
+
+      ActiveRecord::Base.transaction do
+
+        # TODO Create an audit
+        # TODO Create an advisory lock to prevent multiple reprocesses from happening at the same time
+        # TODO implement last_id
+
+        reset_count = reset_activity_entries
+        deleted_count = delete_register_items
+        queued_count = queue_activities_for_reun
+
+        # We completed resending them; from a user perspective, the doesn't complete until the stream is finished processing
+        log_info("Reun completed. register_items_deleted=#{deleted_count} activities_reset=#{reset_count} queued=#{queued_count}")
+      end
+    end
+
+    private
+
+    attr_reader :app, :start_at, :logger, :last_id, :run_id
+
+    def validate_params!
+      raise "start_at required" unless start_at.present?
+      raise "app required" unless app.present?
+    end
+
+    def delete_register_items
+      total_count = 0
+       RegisterItem
+        .where(
+          app_id: app.id,
+          originated_at: start_at..,
+          invoice_id: nil
+        )
+      .in_batches(of: BATCH_SIZE) do |register_items|
+
+        # We'll do a full reset of the activity in a separate step, but we need to dissassociate the register items
+        # from the activity entries first, to satisfy the foriegn key constraint.
+        # We do this in a separate step because there isn't a 1:1 between activities and register_items
+        ActivityEntry.where(register_item_id: register_items.pluck(:id))
+        .update_all(register_item_id: nil)
+
+        batch_count = register_items.delete_all
+        total_count += batch_count
+
+        log_info("Register items batch deleted. batch_count: #{batch_count}, total_count: #{total_count}")
+      end
+
+      log_info("Register items deleted. count=#{total_count}")
+      total_count
+    end
+
+    def reset_activity_entries
+      total_count = 0
+      ActivityEntry
+        .where(
+          app_id: app.id,
+          created_at: start_at..,
+          activity_type: 'request',
+        )
+        .where.not(register_item_id: nil)
+        .in_batches(of: BATCH_SIZE) do |activity_entries|
+          batch_count = activity_entries.update_all(
+            register_item_id: nil,
+            diagnostics: nil,
+            status: nil,
+            duration_ms: nil
+          )
+          total_count += batch_count
+
+          log_info("Activity entries batch reset. batch_count: #{batch_count}, total_count: #{total_count}")
+        end
+
+      log_info("Activity entries reset. count=#{total_count}")
+      total_count
+    end
+
+    def queue_activities_for_reun
+      key = "app_#{app.id}_rerun_#{run_id}"
+      queued_count = 0
+      last_id = nil
+      ActivityEntry
+        .select(:id, :app_id, :created_at)
+        .where(app_id: app.id, created_at: start_at.., activity_type: 'request')
+        .in_batches(of: BATCH_SIZE) do |activity_entries|
+          payload = {
+            activity_entry_ids: activity_entries.collect(&:id),
+            key: key,
+          }
+          KAFKA.produce_sync(
+            topic: Services::Kafka.topic,
+            payload: payload.to_json,
+            key: key
+          )
+          queued_count += activity_entries.size
+          last_id = activity_entries.last.id
+        end
+        log_info("Activities queued. count=#{queued_count}")
+        return queued_count
+      rescue StandardError => e
+        log_info("Requeing failed. last_id=#{last_id}")
+        puts e.message
+        puts e.backtrace.join("\n")
+        raise
+    end
+
+    def log_info(message)
+      logger.info("[ActivityRerun] run_id=#{run_id} app_id=#{app.name} start_at=#{start_at.iso8601} #{message}")
+    end
+
+  end # class ActivityRerun
+end # module Services

--- a/lib/services/activity_rerun.rb
+++ b/lib/services/activity_rerun.rb
@@ -53,6 +53,7 @@ module Services
 
     def delete_register_items
       total_count = 0
+
        RegisterItem
         .where(
           app_id: app.id,
@@ -66,7 +67,6 @@ module Services
         # We do this in a separate step because there isn't a 1:1 between activities and register_items
         ActivityEntry.where(register_item_id: register_items.pluck(:id))
         .update_all(register_item_id: nil)
-
         batch_count = register_items.delete_all
         total_count += batch_count
 

--- a/lib/services/activity_rerun.rb
+++ b/lib/services/activity_rerun.rb
@@ -1,14 +1,9 @@
-# Usage:
-# ActivityRerun.new(app, start_at).call
-
 # Logging signature:
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Reun started
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Register items deleted. count=1500
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Activity entries reset. count=1500
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Queueing activities. total=10000
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Batch processed. processed=2000 total=10000
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Activities queued. count=10000
-# [ActivityRerun] app_id=123 start_at=2024-11-14T10:00:00Z Reun completed. deleted=1500 reset=1500 reprocessed=10000
+# [ActivityRerun] run_id=788287 app_id=0a7f5bc49c8190 start_at=2024-10-01T00:00:00-07:00 Rerun started
+# [ActivityRerun] run_id=788287 app_id=0a7f5bc49c8190 start_at=2024-10-01T00:00:00-07:00 Activity entries reset. count=0
+# [ActivityRerun] run_id=788287 app_id=0a7f5bc49c8190 start_at=2024-10-01T00:00:00-07:00 Register items deleted. count=0
+# [ActivityRerun] run_id=788287 app_id=0a7f5bc49c8190 start_at=2024-10-01T00:00:00-07:00 Activities queued. count=19392
+# [ActivityRerun] run_id=788287 app_id=0a7f5bc49c8190 start_at=2024-10-01T00:00:00-07:00 Rerun completed. register_items_deleted=0 activities_reset=0 queued=19392
 
 module Services
 
@@ -26,7 +21,7 @@ module Services
     end
 
     def call
-      log_info("Reun started")
+      log_info("Rerun started")
       validate_params!
       ActiveRecord::Base.transaction do
         # TODO Create an audit
@@ -36,9 +31,9 @@ module Services
         end
         reset_count = reset_activity_entries
         deleted_count = delete_register_items
-        queued_count = queue_activities_for_reun
-        log_info("Reun completed. register_items_deleted=#{deleted_count} activities_reset=#{reset_count} queued=#{queued_count}")
-        return true
+        queued_count = queue_activities_for_rerun
+        log_info("Rerun completed. register_items_deleted=#{deleted_count} activities_reset=#{reset_count} queued=#{queued_count}")
+        true
       end
     end
 
@@ -112,7 +107,7 @@ module Services
       total_count
     end
 
-    def queue_activities_for_reun
+    def queue_activities_for_rerun
       key = "app_#{app.id}_rerun_#{run_id}"
       queued_count = 0
       ActivityEntry
@@ -132,7 +127,7 @@ module Services
           @last_id = activity_entries.last.id
         end
         log_info("Activities queued. count=#{queued_count}")
-        return queued_count
+        queued_count
       rescue StandardError => e
         log_info("Requeing failed. last_id=#{last_id}")
         puts e.message

--- a/lib/tasks/assign_app_ids_from_tags.rake
+++ b/lib/tasks/assign_app_ids_from_tags.rake
@@ -1,0 +1,46 @@
+# Usage: rake assign_app_ids_from_tags:run
+
+namespace :assign_app_ids_from_tags do
+  desc "Attaches app IDs to register_items based on app tags"
+  task run: :environment do
+    begin
+
+      # There is a convention prior to now that is being made official. Currently, a contract is tagged with a customer_id, that
+      # contract is used to create register items, and the register items contain the customer_id. This makes the link
+      # between the register item the contract that produced it explicit, making it easier to predictably re-run all events produced by a contract.
+      # If there are mutiple app tags assigned to the same customer, the most recently created will take precedence.
+
+      # 1. Get apps with tags and fish out the customer_id so we have a list of app_id: customer_id
+      customer_tags = Tag.where(taggable_type: "App", context: "customer_id")
+      customer_app_ids = customer_tags.collect do |tag| {app_id: tag.taggable_id, customer_id: tag.name } end
+      # => [{:app_id=>53, :customer_id=>"194"}, {:app_id=>53, :customer_id=>"2789"}]
+
+
+      # 2. Find the meta column for the customer_id for each register
+      Register.all.each do |register|
+        customer_id_meta = register.meta.find { |k,v,| v == 'customer_id' }
+        #  => ["meta0", "customer_id"]
+        if !customer_id_meta || customer_id_meta.length == 0
+          puts "No customer_id meta column, skipping register #{register.name}"
+          next
+        end
+        customer_id_meta = customer_id_meta[0]
+
+        # 3. Iterate through our list of app_id: customer_id and update the meta column in the register items
+        customer_app_ids.each do |app|
+          puts "Assigning app_id: #{app[:app_id]} to customer_id: #{app[:customer_id]}"
+          count = RegisterItem
+            .where(register_id: register.id)
+            .where("#{customer_id_meta} = ?", app[:customer_id])
+            .update_all(app_id: app[:app_id])
+          puts "Updated #{count} register items for app_id: #{app[:app_id]}"
+        end
+      end
+
+      puts 'App Ids attaching completed successfully'
+    rescue => e
+      puts "App Ids attaching failed: #{e.message}"
+      raise e
+    end
+  end
+end

--- a/test/fixtures/activity_entries.yml
+++ b/test/fixtures/activity_entries.yml
@@ -1,0 +1,29 @@
+rerun_before_start_date:
+  id: 1
+  app_id: 1
+  update_id:
+  activity_type: request
+  status: 200
+  source: test
+  duration_ms: 100
+  payload: {}
+  diagnostics: []
+  owner_id: 1
+  owner_type: Organization
+  register_item_id: 3
+  created_at: <%= Time.parse("2024-11-01 00:00:00") - 1.day %>
+
+rerun_after_start_date:
+  id: 2
+  app_id: 1
+  update_id:
+  activity_type: request
+  status: 200
+  source: test
+  duration_ms: 100
+  payload: {}
+  diagnostics: []
+  owner_id: 1
+  owner_type: Organization
+  register_item_id: 3
+  created_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>

--- a/test/fixtures/activity_entries.yml
+++ b/test/fixtures/activity_entries.yml
@@ -27,3 +27,18 @@ rerun_after_start_date:
   owner_type: Organization
   register_item_id: 3
   created_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
+
+rerun_after_start_date_two:
+  id: 3
+  app_id: 1
+  update_id:
+  activity_type: request
+  status: 200
+  source: test
+  duration_ms: 100
+  payload: {}
+  diagnostics: []
+  owner_id: 1
+  owner_type: Organization
+  register_item_id: 3
+  created_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>

--- a/test/fixtures/apps.yml
+++ b/test/fixtures/apps.yml
@@ -1,6 +1,6 @@
 one:
   id: 1
-  port: 777
+  port: 3002
   name: one
   descriptive_name: friendly name one
   hostname: ''
@@ -10,7 +10,7 @@ one:
   owner_id: 1
 two:
   id: 2
-  port: 778
+  port: 3003
   name: two
   descriptive_name: friendly name two
   hostname: ''

--- a/test/fixtures/apps.yml
+++ b/test/fixtures/apps.yml
@@ -1,0 +1,20 @@
+one:
+  id: 1
+  port: 777
+  name: one
+  descriptive_name: friendly name one
+  hostname: ''
+  domain: ''
+  load_balancer: ''
+  owner_type: Organization
+  owner_id: 1
+two:
+  id: 2
+  port: 778
+  name: two
+  descriptive_name: friendly name two
+  hostname: ''
+  domain: ''
+  load_balancer: ''
+  owner_type: Organization
+  owner_id: 2

--- a/test/fixtures/register_items.yml
+++ b/test/fixtures/register_items.yml
@@ -29,3 +29,58 @@ two:
   owner_id: 1
   owner_type: Organization
   originated_at: 2023-09-22 17:00:00
+
+before_start_date:  # Used in filtering tests to verify date range exclusions
+  app: one
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") - 1.day %>
+  invoice_id:
+  register: one
+  description: "Test Item 3"
+  amount: 300
+  units: 3
+  owner: one
+  unique_key: 1
+
+with_invoice:  # Used in deletion tests to verify items with invoices are preserved
+  app: one
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
+  invoice_id: 123
+  register: one
+  description: "Test Item 4"
+  amount: 400
+  units: 4
+  owner: one
+  unique_key: 2
+
+other_app:  # Used in app-specific filtering tests
+  app: two
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
+  invoice_id:
+  register: one
+  description: "Test Item 5"
+  amount: 500
+  units: 5
+  owner: one
+  unique_key: 3
+
+deletable_one:  # Used in bulk deletion tests
+  app: one
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
+  invoice_id:
+  register: one
+  description: "Test Item 1"
+  amount: 100
+  units: 1
+  owner: one
+  unique_key: 4
+
+deletable_two:  # Used in bulk deletion tests
+  app: one
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 2.days %>
+  invoice_id:
+  register: one
+  description: "Test Item 2"
+  amount: 200
+  units: 2
+  owner: one
+  unique_key: 5

--- a/test/fixtures/register_items.yml
+++ b/test/fixtures/register_items.yml
@@ -6,6 +6,7 @@
 #
 one:
   id: 1
+  app_id: 1
   register_id: 1
   description: "Register Item 1 description"
   units: USD
@@ -19,7 +20,8 @@ one:
 
 two:
   id: 2
-  register_id: 2
+  app_id: 1
+  register_id: 1
   description: "Register Item 2 description"
   units: USD
   amount: 9.55
@@ -30,57 +32,77 @@ two:
   owner_type: Organization
   originated_at: 2023-09-22 17:00:00
 
-before_start_date:  # Used in filtering tests to verify date range exclusions
-  app: one
+rerun_before_start_date:
+  id: 3
+  app_id: 1
+  register_id: 1
+  description: "Test Item 3"
+  units: USD
+  amount: 300
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
   originated_at: <%= Time.parse("2024-11-01 00:00:00") - 1.day %>
   invoice_id:
-  register: one
-  description: "Test Item 3"
-  amount: 300
-  units: 3
-  owner: one
-  unique_key: 1
 
-with_invoice:  # Used in deletion tests to verify items with invoices are preserved
-  app: one
-  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
-  invoice_id: 123
-  register: one
+rerun_with_invoice:
+  id: 4
+  app_id: 1
+  register_id: 1
   description: "Test Item 4"
+  units: USD
   amount: 400
-  units: 4
-  owner: one
-  unique_key: 2
-
-other_app:  # Used in app-specific filtering tests
-  app: two
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
   originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
-  invoice_id:
-  register: one
+  invoice_id: 1
+
+rerun_other_app:
+  id: 5
+  app_id: 2
+  register_id: 1
   description: "Test Item 5"
+  units: USD
   amount: 500
-  units: 5
-  owner: one
-  unique_key: 3
-
-deletable_one:  # Used in bulk deletion tests
-  app: one
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
   originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
   invoice_id:
-  register: one
-  description: "Test Item 1"
-  amount: 100
-  units: 1
-  owner: one
-  unique_key: 4
 
-deletable_two:  # Used in bulk deletion tests
-  app: one
+rerun_deletable_one:
+  id: 6
+  app_id: 1
+  register_id: 1
+  description: "Test Item 1"
+  units: USD
+  amount: 100
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
+  originated_at: <%= Time.parse("2024-11-01 00:00:00") + 1.day %>
+  invoice_id:
+
+rerun_deletable_two:
+  id: 7
+  app_id: 1
+  register_id: 1
+  description: "Test Item 2"
+  units: USD
+  amount: 200
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
   originated_at: <%= Time.parse("2024-11-01 00:00:00") + 2.days %>
   invoice_id:
-  register: one
-  description: "Test Item 2"
-  amount: 200
-  units: 2
-  owner: one
-  unique_key: 5

--- a/test/lib/services/activity_rerun.rb
+++ b/test/lib/services/activity_rerun.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class ActivityRerunTest < ActiveSupport::TestCase
+  fixtures :apps
+
+  def setup
+    @app = apps(:one)
+    @start_at = Time.parse"2024-11-01 00:00:00"
+
+    @register = registers(:one)
+    @owner = organizations(:one)
+
+  # Store IDs as we create records
+    @before_start_at_id = RegisterItem.create!(
+      app: @app, originated_at: @start_at - 1.day, invoice_id: nil,
+      register: @register, description: "Test Item 3", amount: 300, units: 3, owner: @owner, unique_key: 1
+    ).id
+
+    @with_invoice_id = RegisterItem.create!(
+      app: @app, originated_at: @start_at + 1.day, invoice_id: 123,
+      register: @register, description: "Test Item 4", amount: 400, units: 4, owner: @owner, unique_key: 2
+    ).id
+
+    @other_app_id = RegisterItem.create!(
+      app: apps(:two), originated_at: @start_at + 1.day, invoice_id: nil,
+      register: @register, description: "Test Item 5", amount: 500, units: 5, owner: @owner, unique_key: 3
+    ).id
+
+    @deletable_id_1 = RegisterItem.create!(
+      app: @app, originated_at: @start_at + 1.day, invoice_id: nil,
+      register: @register, description: "Test Item 1", amount: 100, units: 1, owner: @owner, unique_key: 4
+    ).id
+
+    @deletable_id_2 = RegisterItem.create!(
+      app: @app, originated_at: @start_at + 2.days, invoice_id: nil,
+      register: @register, description: "Test Item 2", amount: 200, units: 2, owner: @owner, unique_key: 5
+    ).id
+
+    @register_item_ids = [
+      @before_start_at_id,
+      @with_invoice_id,
+      @other_app_id,
+      @deletable_id_1,
+      @deletable_id_2
+    ]
+  end
+
+  test 'can instantiate' do
+    service = Services::ActivityRerun.new(@app, @start_at)
+    assert_instance_of Services::ActivityRerun, service
+  end
+
+  test 'generates a 6 digit run_id' do
+    service = Services::ActivityRerun.new(@app, @start_at)
+    run_id = service.send(:run_id)
+    assert_match(/^\d{6}$/, run_id)
+  end
+
+  test 'delete_register_items removes eligible records after start_at' do
+    service = Services::ActivityRerun.new(@app, @start_at)
+
+    deleted_count = service.send(:delete_register_items)
+    assert_equal 2, deleted_count, "Expected 2 records to be deleted"
+
+    remaining_records = RegisterItem.where(id: @register_item_ids)
+    assert_equal 3, remaining_records.count, "Expected 3 records to remain"
+
+    # These IDs should still exist
+    assert RegisterItem.exists?(@before_start_at_id), "Expected ID @before_start_at_id to still exist"
+    assert RegisterItem.exists?(@with_invoice_id), "Expected ID @with_invoice_id to still exist"
+    assert RegisterItem.exists?(@other_app_id), "Expected ID @other_app_id to still exist"
+
+    # These IDs should be gone
+    refute RegisterItem.exists?(@deletable_id_1), "Expected ID @deletable_id_1 to be deleted"
+    refute RegisterItem.exists?(@deletable_id_2), "Expected ID @deletable_id_2 to be deleted"
+  end
+
+end

--- a/test/lib/services/activity_rerun.rb
+++ b/test/lib/services/activity_rerun.rb
@@ -79,9 +79,9 @@ class ActivityRerunTest < ActiveSupport::TestCase
     assert_not_nil @rerun_before_start_date.duration_ms, "Expected duration_ms to be unchanged"
   end
 
-  test 'queue_activities_for_reun queues eligible records after start' do
+  test 'queue_activities_for_rerun queues eligible records after start' do
     service = Services::ActivityRerun.new(@app, @start_at)
-    queued_count = service.send(:queue_activities_for_reun)
+    queued_count = service.send(:queue_activities_for_rerun)
     assert_equal 2, queued_count, "Expected 2 records to be queued"
     assert_equal @rerun_after_start_date_two.id, service.last_id, "Expected last_id to be set to the last queued record"
   end


### PR DESCRIPTION
**Before**
No mechanism to "replay" activity after contract changes are made.

**After**
A service provides a safe way to coordinate the deletion of register items and re-queue the payloads. This is being written alongside a utility UI:
 
![Screenshot 2024-11-20 at 4 22 31 PM](https://github.com/user-attachments/assets/fe540ceb-c1e5-4372-aef4-6a33a62cf470)

Key behavior:
- Deletes un-invoiced register items owned by an app that are newer than a provided date
- Disassociates the activity for the app after the provided date any register item
- Creates events in the kafka stream with a list of IDs, in batches of 1000. This makes the re-queueing relatively performant, while leaving the heavier work of fetching payloads and writing register items to the event consumer.
- Creates an advisory lock to prevent multiple runs operating at the same time. The lock is released when the items are added to queue, not when they have finished. For this reason and others, we may want to create a table to track when the updates are fully finished _out_ of the stream, and use that as the basis for an additional lock and status for very long running jobs, which are expected to survive container swaps, etc..

Note:
This has an implied dependency on Kafka

TODO
- [ ] ~~Create an audit~~ We'll let the application logs be our audit while we validate the concept
- [x] Feedback on completion / failure