### PR TITLE
handle already json manifest on webhook send

### DIFF
--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -38,9 +38,8 @@ class ActivityEntry < ApplicationRecord
   end
 
   def webhook_path
-    manifest = ActiveSupport::JSON.decode(
-      app.manifests.order(created_at: :desc).first.try(:content) || 'null'
-    )
+    manifest = app.manifests.order(created_at: :desc).first.try(:content) || 'null'
+    manifest = ActiveSupport::JSON.decode if manifest.is_a?(String)
     manifest.try(:[], 'listen_at').try(:[], 'path') || '/webhooks/receive'
   end
 

--- a/app/models/activity_entry.rb
+++ b/app/models/activity_entry.rb
@@ -39,7 +39,7 @@ class ActivityEntry < ApplicationRecord
 
   def webhook_path
     manifest = app.manifests.order(created_at: :desc).first.try(:content) || 'null'
-    manifest = ActiveSupport::JSON.decode if manifest.is_a?(String)
+    manifest = ActiveSupport::JSON.decode(manifest) if manifest.is_a?(String)
     manifest.try(:[], 'listen_at').try(:[], 'path') || '/webhooks/receive'
   end
 


### PR DESCRIPTION
**Before**
Scheduled apps fail trying to retrieve their webhook path:
```
Starting Scheduled Every 10 minutes apps...
Running 7aff304f69535d, Solid Fantasy
Error running 7aff304f69535d, Solid Fantasy: no implicit conversion of Hash into String
```

**After**
Scheduled apps should now work as expected. Locally, this is now failing with a TCP error because the env is not configured, but proves we're getting past the line in question.

```
Starting Scheduled Every 10 minutes apps...
Running 7aff304f69535d, Solid Fantasy
Error running 7aff304f69535d, Solid Fantasy: Failed to open TCP connection to 7aff304f69535d.staging.trivialapps.io:443 (getaddrinfo: nodename nor servname provided, or not known)
Completed 7aff304f69535d, Solid Fantasy
Completed Scheduled Every 10 minutes apps.

```