### PR TITLE
Bugfixes/rerun

### DIFF
--- a/app/controllers/activity_entries_controller.rb
+++ b/app/controllers/activity_entries_controller.rb
@@ -5,9 +5,6 @@ class ActivityEntriesController < ApplicationController
   # Prevent an extra auth header from being set after a stream is opened
   skip_after_action :update_auth_header, only: [:rerun]
 
-  # Enable streaming
-  include ActionController::Live
-
   def index
     authorize! :index, ActivityEntry
 
@@ -50,19 +47,20 @@ class ActivityEntriesController < ApplicationController
     @app = current_user.associated_apps.kept.find_by_name!(params[:app_id])
     authorize! :update, @app
     start_at = params.require(:start_at)
-    start_at = Time.parse(start_at) if start_at.is_a?(String)
-    headers["Content-Type"] = "text/event-stream"
-    response.headers["Last-Modified"] = Time.now.httpdate # Add this line if your Rack version is 2.2.x, which we are as of 2024-11-21
+    end_at = params.require(:end_at)
+    run_id = SecureRandom.random_number(1_000_000).to_s.rjust(6, '0')
 
-    service = Services::ActivityRerun.new(@app, start_at)
-    service.call do |progress|
-      response.stream.write("#{progress.to_json}\n\n")
-    end
-
-  rescue StandardError => exception
-    response.stream.write("error: #{exception.message}\n\n")
-  ensure
-    response.stream.close
+    RerunActivityJob.perform_later(
+      app: @app,
+      start_at: start_at.is_a?(String) ? Time.parse(start_at) : start_at,
+      end_at: end_at.is_a?(String) ? Time.parse(end_at) : end_at,
+      run_id:
+    )
+    render json: {
+      status: 'success',
+      message: "Rerun started. Run ID: #{run_id}",
+      run_id:
+    }
   end
 
   def show

--- a/app/jobs/rerun_activity_job.rb
+++ b/app/jobs/rerun_activity_job.rb
@@ -1,0 +1,8 @@
+class RerunActivityJob < ApplicationJob
+  queue_as :default
+
+  def perform(options)
+    service = Services::ActivityRerun.new(**options)
+    service.call
+  end
+end

--- a/lib/services/activity_rerun.rb
+++ b/lib/services/activity_rerun.rb
@@ -12,17 +12,17 @@ module Services
 
     attr_accessor :app, :start_at, :end_at, :logger, :last_id, :run_id
 
-    def initialize(app, start_at, end_at)
+    def initialize(app:, start_at:, end_at:, run_id:)
       @app = app
       @start_at = start_at
       @end_at = end_at
+      @run_id = run_id
       @logger = Rails.logger
       @last_id = nil
-      @run_id = SecureRandom.random_number(1_000_000).to_s.rjust(6, '0')
     end
 
     def call(&block)
-      log_info("Rerun started", &block)
+      log_info("Rerun started, app_id=#{app.name} start_at=#{start_at.iso8601} end_at=#{end_at.iso8601}", &block)
       validate_params!
       ActiveRecord::Base.transaction do
         # TODO Create an audit
@@ -130,7 +130,7 @@ module Services
     end
 
     def log_info(message, &block)
-      logger.info("[ActivityRerun] run_id=#{run_id} app_id=#{app.name} start_at=#{start_at.iso8601} end_at=#{end_at.iso8601} #{message}")
+      logger.info("[ActivityRerun] run_id=#{run_id} #{message}")
       yield({run_id: run_id, app_id: app.name, start_at: start_at.iso8601, end_at: end_at.iso8601, message: }) if block_given?
     end
 

--- a/test/fixtures/register_items.yml
+++ b/test/fixtures/register_items.yml
@@ -124,7 +124,7 @@ already_invoiced:
 
 ready_to_invoice_warehouse_one:
   id: 9,
-  app_id: 1,
+  app_id: 2,
   register_id: 4,
   amount: 100
   description: 'Test'
@@ -139,7 +139,7 @@ ready_to_invoice_warehouse_one:
 
 ready_to_invoice_warehouse_two:
   id: 10,
-  app_id: 1,
+  app_id: 2,
   register_id: 4,
   amount: 150
   description: 'Test'
@@ -154,7 +154,7 @@ ready_to_invoice_warehouse_two:
 
 ready_to_invoice_wrong_customer:
   id: 11,
-  app_id: 1,
+  app_id: 2,
   register_id: 4,
   amount: 150
   description: 'Test'

--- a/test/fixtures/register_items.yml
+++ b/test/fixtures/register_items.yml
@@ -107,6 +107,21 @@ rerun_deletable_two:
   originated_at: <%= Time.parse("2024-11-01 00:00:00") + 2.days %>
   invoice_id:
 
+rerun_not_deletable_by_end_at:
+  id: 12
+  app_id: 1
+  register_id: 1
+  description: "rerun_not_deletable_by_end_at"
+  units: USD
+  amount: 200
+  meta1:
+  meta2:
+  meta3:
+  owner_id: 1
+  owner_type: Organization
+  originated_at: <%= Time.parse("2024-12-01 00:00:00") %>
+  invoice_id:
+
 already_invoiced:
   id: 8,
   app_id: 1,

--- a/test/lib/services/activity_rerun.rb
+++ b/test/lib/services/activity_rerun.rb
@@ -5,6 +5,7 @@ class ActivityRerunTest < ActiveSupport::TestCase
   def setup
     @app = apps(:one)
     @start_at = Time.parse("2024-11-01 00:00:00")
+    @end_at = Time.parse("2024-11-30 23:59:59")
     @register = registers(:one)
     @owner = organizations(:one)
 
@@ -30,18 +31,18 @@ class ActivityRerunTest < ActiveSupport::TestCase
   end
 
   test 'can instantiate' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
     assert_instance_of Services::ActivityRerun, service
   end
 
   test 'generates a 6 digit run_id' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
     run_id = service.send(:run_id)
     assert_match(/^\d{6}$/, run_id)
   end
 
   test 'delete_register_items removes eligible records after start_at' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
 
     deleted_count = service.send(:delete_register_items)
     assert_equal 2, deleted_count, "Expected 2 records to be deleted"
@@ -60,7 +61,7 @@ class ActivityRerunTest < ActiveSupport::TestCase
   end
 
   test 'reset_activity_entries resets eligible records after start' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
 
     reset_count = service.send(:reset_activity_entries)
     assert_equal 2, reset_count, "Expected 2 records to be reset"
@@ -80,14 +81,14 @@ class ActivityRerunTest < ActiveSupport::TestCase
   end
 
   test 'queue_activities_for_rerun queues eligible records after start' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
     queued_count = service.send(:queue_activities_for_rerun)
     assert_equal 2, queued_count, "Expected 2 records to be queued"
     assert_equal @rerun_after_start_date_two.id, service.last_id, "Expected last_id to be set to the last queued record"
   end
 
   test 'lock key contains app id' do
-    service = Services::ActivityRerun.new(@app, @start_at)
+    service = Services::ActivityRerun.new(@app, @start_at, @end_at)
     assert_equal "rerun_app_#{@app.id}", service.send(:lock_key)
   end
 


### PR DESCRIPTION
At production scale, rerun was determined to have a number of issues:
1. Without an end date, it's impossible to create small jobs to heal known outages
2. There's no automatic heartbeat with ActionController:live, so it's prone to network interruptions
3. We don't know how many batches there will be, so the logs of "did 1000" aren't as helpful as they should be to create any kind of progress estimate
4. Large datasets timeout in the reset phase

This PR:
- Assigns an ID and moves the entire process into a background job
- Keeps the UI simple and fully delegates logging to application logs
- Provides meta and batch identity to event consumer, which uses an aligned logging format to provide progress reports
- Provides a final `[ActivityRerun] rerun <ID> Reset step 4 of 4 completed, all activities reprocessed`