### PR TITLE
fix/void_api_register

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -2,7 +2,7 @@ class RegisterItemsController < ApplicationController
   include Exportable
   self.export_serializer = RegisterItemSerializer
 
-  before_action :set_register, except: %i[void]
+  before_action :set_register
   before_action :set_register_item, only: %i[ show update ]
   before_action :set_register_items, only: %i[ index sum void ]
   before_action :set_pagination, only: %i[index]


### PR DESCRIPTION
set the `register` when using the `void` end-point