### PR TITLE
enhance/prevent_update_after_invoice

### DIFF
--- a/app/controllers/register_items_controller.rb
+++ b/app/controllers/register_items_controller.rb
@@ -4,6 +4,7 @@ class RegisterItemsController < ApplicationController
 
   before_action :set_register
   before_action :set_register_item, only: %i[ show update ]
+  before_action :prevent_alteration, if: -> { @register_item.invoice_id.present? }, only: %i[ update ]
   before_action :set_register_items, only: %i[ index sum void ]
   before_action :set_pagination, only: %i[index]
   before_action :set_ordering, only: %i[index]
@@ -177,5 +178,9 @@ class RegisterItemsController < ApplicationController
       end
     end
     permitted_params
+  end
+
+  def prevent_alteration
+    render json: { error: 'RegisterItem is in a locked state' }, status: :forbidden
   end
 end

--- a/spec/requests/register_items_spec.rb
+++ b/spec/requests/register_items_spec.rb
@@ -10,6 +10,7 @@ describe "Charts API", type: :request do
   let(:organization) { FactoryBot.create :organization, admin: user }
   let(:other_register) { organization.owned_registers.first }
   let(:current_register) { FactoryBot.create :register, owner: organization }
+  let!(:register_item) { FactoryBot.create(:register_item, register: current_register, originated_at: Time.now) }
 
   def self.sum_schema
     {
@@ -21,10 +22,44 @@ describe "Charts API", type: :request do
     }
   end
 
+  def self.register_item_schema
+     {
+       type: :object,
+       properties: {
+         id: { type: :integer },
+         register_id: { type: :integer },
+         owner_type: { type: :string },
+         owner_id: { type: :integer },
+         unique_key: { type: :string },
+         description: { type: :string },
+         amount: { type: :string },
+         units: { type: :string },
+         invoice_id: { type: :integer },
+         originated_at: { type: :string },
+         created_at: { type: :string }
+       },
+       required: %w[id register_id owner_type owner_id unique_key description amount units invoice_id originated_at created_at]
+     }
+  end
+
+  def self.register_item_body_schema
+    {
+      type: :object,
+      properties: {
+        public_app_id: { type: :integer },
+        unique_key: { type: :string },
+        description: { type: :string },
+        register_id: { type: :integer },
+        amount: { type: :number },
+        units: { type: :string },
+        originated_at: { type: :string }
+      }
+    }
+  end
+
   before do
     FactoryBot.create(:register_item, register: current_register, originated_at: Time.now - 2.weeks)
     FactoryBot.create(:register_item, register: current_register, originated_at: Time.now - 1.week)
-    FactoryBot.create(:register_item, register: current_register, originated_at: Time.now)
     FactoryBot.create(:register_item, register: other_register, originated_at: Time.now)
   end
 
@@ -47,7 +82,7 @@ describe "Charts API", type: :request do
         end
       end
 
-      response '200', 'Get a sum of register_items, no filters' do
+      response '200', 'Get a sum of register_items, filtered on register' do
         schema type: sum_schema
 
         let(:register_id) { current_register.id }
@@ -60,6 +95,49 @@ describe "Charts API", type: :request do
       response '400', "injection attempt on sum column" do
         let(:col) { 'DROP TABLE users' }
         run_test!
+      end
+    end
+  end
+
+  path '/register_items/{register_item_id}' do
+    parameter name: 'register_item_id', in: :path, type: :integer
+    parameter name: 'register_id', in: :query, type: :integer
+    let(:register_id) { current_register.id }
+    let(:register_item_id) { register_item.id }
+
+    put 'Update a RegisterItem' do
+      tags 'RegisterItem'
+      security [ { access_token: [], client: [], uid: [] } ]
+      consumes 'application/json'
+      produces 'register_item/json'
+
+      parameter name: 'register_item_update', in: :body, schema: register_item_body_schema
+      let(:register_item_update) {
+        {
+          amount: 2.17
+        }
+      }
+      response '200', 'Update RegisterItem' do
+        schema type: register_item_schema
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['amount']).to eq("2.17")
+        end
+      end
+
+      response '403', 'Update an Invoiced RegisterItem' do
+        schema type: register_item_schema
+
+        before do
+          register_item.invoice = FactoryBot.create :invoice, owner: organization
+          register_item.save!
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['error']).to eq('RegisterItem is in a locked state')
+        end
       end
     end
   end


### PR DESCRIPTION
**Before**
invoiced `register_items` could still be updated via the controller

**After**
`register_items` are locked from alteration at the controller level when the belong to an `invoice`